### PR TITLE
Add standing instruction to proactively report work, tests, problems

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,12 @@
 # Working preferences
 
 - Before starting any coding task in this repo, invoke the `andrej-karpathy-skills:karpathy-guidelines` skill.
+
+## Reporting
+
+After finishing any task (or a meaningful chunk of one), always report to the user:
+- **What was done** — a full summary of the actions/changes made, not just the end state.
+- **Test/verification results** — what was run and whether it passed, not just "done".
+- **Problems encountered** — anything that broke, was misdiagnosed, or needed a workaround, and how it was resolved.
+
+Do this proactively, without waiting to be asked.


### PR DESCRIPTION
## Summary
Adds a "Reporting" section to `CLAUDE.md` instructing Claude to proactively report, after finishing any task: what was done, test/verification results, and any problems encountered — without waiting to be asked.

Doc-only change, no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)