### PR TITLE
Add Diagram entity, repositories, and DiagramService

### DIFF
--- a/backend/src/main/java/dev/omnidiagram/backend/diagram/Diagram.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/diagram/Diagram.java
@@ -1,0 +1,60 @@
+package dev.omnidiagram.backend.diagram;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.generator.EventType;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "diagrams")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Diagram {
+
+	@Id
+	@Column(insertable = false, updatable = false)
+	@Generated(event = EventType.INSERT)
+	private UUID id;
+
+	@Column(name = "share_token", insertable = false, updatable = false)
+	@Generated(event = EventType.INSERT)
+	private UUID shareToken;
+
+	private String title;
+
+	@Enumerated(EnumType.STRING)
+	private DiagramKind kind;
+
+	private String content;
+
+	@JdbcTypeCode(SqlTypes.JSON)
+	private Map<String, Position> layout = new LinkedHashMap<>();
+
+	@Column(name = "created_at", insertable = false, updatable = false)
+	@Generated(event = EventType.INSERT)
+	private Instant createdAt;
+
+	@Column(name = "updated_at", insertable = false)
+	@Generated(event = EventType.INSERT)
+	private Instant updatedAt;
+
+	public Diagram(DiagramKind kind, String title, String content) {
+		this.kind = kind;
+		this.title = title;
+		this.content = content;
+	}
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/diagram/DiagramKind.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/diagram/DiagramKind.java
@@ -1,0 +1,6 @@
+package dev.omnidiagram.backend.diagram;
+
+public enum DiagramKind {
+	SchemaDiagram,
+	GenericDiagram
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/diagram/DiagramNotFoundException.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/diagram/DiagramNotFoundException.java
@@ -1,0 +1,10 @@
+package dev.omnidiagram.backend.diagram;
+
+import java.util.UUID;
+
+public class DiagramNotFoundException extends RuntimeException {
+
+	public DiagramNotFoundException(UUID id) {
+		super("Diagram not found: " + id);
+	}
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/diagram/DiagramRepository.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/diagram/DiagramRepository.java
@@ -1,0 +1,13 @@
+package dev.omnidiagram.backend.diagram;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiagramRepository extends JpaRepository<Diagram, UUID> {
+
+	Optional<Diagram> findByShareToken(UUID shareToken);
+
+	List<Diagram> findAllByOrderByUpdatedAtDesc();
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/diagram/DiagramService.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/diagram/DiagramService.java
@@ -1,0 +1,69 @@
+package dev.omnidiagram.backend.diagram;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class DiagramService {
+
+	private final DiagramRepository diagramRepository;
+	private final RevisionRepository revisionRepository;
+
+	public DiagramService(DiagramRepository diagramRepository, RevisionRepository revisionRepository) {
+		this.diagramRepository = diagramRepository;
+		this.revisionRepository = revisionRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public List<Diagram> listAll() {
+		return diagramRepository.findAllByOrderByUpdatedAtDesc();
+	}
+
+	@Transactional(readOnly = true)
+	public Diagram getById(UUID id) {
+		return findDiagram(id);
+	}
+
+	@Transactional(readOnly = true)
+	public Diagram getByShareToken(UUID shareToken) {
+		return diagramRepository.findByShareToken(shareToken)
+				.orElseThrow(() -> new DiagramNotFoundException(shareToken));
+	}
+
+	public Diagram create(DiagramKind kind, String title, String content) {
+		return diagramRepository.save(new Diagram(kind, title, content));
+	}
+
+	public Diagram update(UUID id, String title, String content, Map<String, Position> layout) {
+		Diagram diagram = findDiagram(id);
+
+		if (content != null || layout != null) {
+			revisionRepository.save(new Revision(diagram.getId(), diagram.getContent(), diagram.getLayout()));
+		}
+		if (title != null) {
+			diagram.setTitle(title);
+		}
+		if (content != null) {
+			diagram.setContent(content);
+		}
+		if (layout != null) {
+			diagram.setLayout(layout);
+		}
+		diagram.setUpdatedAt(Instant.now());
+
+		return diagramRepository.save(diagram);
+	}
+
+	public void delete(UUID id) {
+		diagramRepository.deleteById(id);
+	}
+
+	private Diagram findDiagram(UUID id) {
+		return diagramRepository.findById(id).orElseThrow(() -> new DiagramNotFoundException(id));
+	}
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/diagram/Position.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/diagram/Position.java
@@ -1,0 +1,4 @@
+package dev.omnidiagram.backend.diagram;
+
+public record Position(double x, double y) {
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/diagram/Revision.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/diagram/Revision.java
@@ -1,0 +1,48 @@
+package dev.omnidiagram.backend.diagram;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.generator.EventType;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "revisions")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Revision {
+
+	@Id
+	@Column(insertable = false, updatable = false)
+	@Generated(event = EventType.INSERT)
+	private UUID id;
+
+	@Column(name = "diagram_id", updatable = false)
+	private UUID diagramId;
+
+	private String content;
+
+	@JdbcTypeCode(SqlTypes.JSON)
+	private Map<String, Position> layout = new LinkedHashMap<>();
+
+	@Column(name = "created_at", insertable = false, updatable = false)
+	@Generated(event = EventType.INSERT)
+	private Instant createdAt;
+
+	public Revision(UUID diagramId, String content, Map<String, Position> layout) {
+		this.diagramId = diagramId;
+		this.content = content;
+		this.layout = layout != null ? layout : new LinkedHashMap<>();
+	}
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/diagram/RevisionRepository.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/diagram/RevisionRepository.java
@@ -1,0 +1,10 @@
+package dev.omnidiagram.backend.diagram;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RevisionRepository extends JpaRepository<Revision, UUID> {
+
+	List<Revision> findAllByDiagramIdOrderByCreatedAtDesc(UUID diagramId);
+}

--- a/backend/src/test/java/dev/omnidiagram/backend/AbstractIntegrationTest.java
+++ b/backend/src/test/java/dev/omnidiagram/backend/AbstractIntegrationTest.java
@@ -10,7 +10,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-abstract class AbstractIntegrationTest {
+public abstract class AbstractIntegrationTest {
 
 	@Container
 	@ServiceConnection

--- a/backend/src/test/java/dev/omnidiagram/backend/diagram/DiagramServiceTest.java
+++ b/backend/src/test/java/dev/omnidiagram/backend/diagram/DiagramServiceTest.java
@@ -1,0 +1,151 @@
+package dev.omnidiagram.backend.diagram;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.omnidiagram.backend.AbstractIntegrationTest;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class DiagramServiceTest extends AbstractIntegrationTest {
+
+	@Autowired
+	private DiagramService diagramService;
+
+	@Autowired
+	private RevisionRepository revisionRepository;
+
+	@Test
+	void createPersistsAndReturnsDiagramWithGeneratedFields() {
+		Diagram diagram = diagramService.create(DiagramKind.SchemaDiagram, "Orders schema",
+				"Table orders { id integer }");
+
+		assertThat(diagram.getId()).isNotNull();
+		assertThat(diagram.getShareToken()).isNotNull();
+		assertThat(diagram.getCreatedAt()).isNotNull();
+		assertThat(diagram.getUpdatedAt()).isNotNull();
+		assertThat(diagram.getLayout()).isEmpty();
+	}
+
+	@Test
+	void createAppendsNoRevision() {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+
+		assertThat(revisionRepository.findAllByDiagramIdOrderByCreatedAtDesc(diagram.getId())).isEmpty();
+	}
+
+	@Test
+	void getByShareTokenFindsTheCreatedDiagramAndThrowsForUnknownToken() {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+
+		Diagram found = diagramService.getByShareToken(diagram.getShareToken());
+
+		assertThat(found.getId()).isEqualTo(diagram.getId());
+		assertThatThrownBy(() -> diagramService.getByShareToken(UUID.randomUUID()))
+				.isInstanceOf(DiagramNotFoundException.class);
+	}
+
+	@Test
+	void getByIdFindsTheCreatedDiagramAndRejectsAShareToken() {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+
+		Diagram found = diagramService.getById(diagram.getId());
+
+		assertThat(found.getId()).isEqualTo(diagram.getId());
+		assertThatThrownBy(() -> diagramService.getById(diagram.getShareToken()))
+				.isInstanceOf(DiagramNotFoundException.class);
+	}
+
+	@Test
+	void updateWithNewContentAppendsOneRevisionHoldingThePreviousContentAndBumpsUpdatedAt() {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+
+		Diagram updated = diagramService.update(diagram.getId(), null, "flowchart LR", null);
+
+		List<Revision> revisions = revisionRepository.findAllByDiagramIdOrderByCreatedAtDesc(diagram.getId());
+		assertThat(revisions).hasSize(1);
+		assertThat(revisions.get(0).getContent()).isEqualTo("flowchart TD");
+		assertThat(updated.getContent()).isEqualTo("flowchart LR");
+		assertThat(updated.getUpdatedAt()).isAfterOrEqualTo(diagram.getUpdatedAt());
+	}
+
+	@Test
+	void updateWithOnlyATitleAppendsNoRevision() {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+
+		Diagram updated = diagramService.update(diagram.getId(), "Renamed", null, null);
+
+		assertThat(updated.getTitle()).isEqualTo("Renamed");
+		assertThat(revisionRepository.findAllByDiagramIdOrderByCreatedAtDesc(diagram.getId())).isEmpty();
+	}
+
+	@Test
+	void updateWithNullContentLeavesContentUnchanged() {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+
+		Diagram updated = diagramService.update(diagram.getId(), "Renamed", null, null);
+
+		assertThat(updated.getContent()).isEqualTo("flowchart TD");
+	}
+
+	@Test
+	void twoSequentialUpdatesBothSucceedAndTheSecondValueWins() {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+
+		diagramService.update(diagram.getId(), null, "flowchart LR", null);
+		Diagram second = diagramService.update(diagram.getId(), null, "flowchart RL", null);
+
+		assertThat(second.getContent()).isEqualTo("flowchart RL");
+	}
+
+	@Test
+	void updatePersistsLayoutAndReadsItBackWithNestedXAndYIntact() {
+		Diagram diagram = diagramService.create(DiagramKind.SchemaDiagram, "Orders schema",
+				"Table orders { id integer }");
+
+		Diagram updated = diagramService.update(diagram.getId(), null, null,
+				Map.of("orders", new Position(10, 20)));
+
+		assertThat(updated.getLayout().get("orders")).isEqualTo(new Position(10, 20));
+
+		Diagram reloaded = diagramService.getById(diagram.getId());
+		assertThat(reloaded.getLayout().get("orders")).isEqualTo(new Position(10, 20));
+	}
+
+	@Test
+	void deleteRemovesTheDiagramAndCascadesItsRevisions() {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+		diagramService.update(diagram.getId(), null, "flowchart LR", null);
+
+		diagramService.delete(diagram.getId());
+
+		assertThatThrownBy(() -> diagramService.getById(diagram.getId()))
+				.isInstanceOf(DiagramNotFoundException.class);
+		assertThat(revisionRepository.findAllByDiagramIdOrderByCreatedAtDesc(diagram.getId())).isEmpty();
+	}
+
+	@Test
+	void listAllOrdersByUpdatedAtDescending() {
+		Diagram first = diagramService.create(DiagramKind.GenericDiagram, "First", "flowchart TD");
+		Diagram second = diagramService.create(DiagramKind.GenericDiagram, "Second", "flowchart TD");
+		diagramService.update(first.getId(), null, "flowchart LR", null);
+
+		List<Diagram> all = diagramService.listAll();
+
+		int firstIndex = indexOf(all, first.getId());
+		int secondIndex = indexOf(all, second.getId());
+		assertThat(firstIndex).isLessThan(secondIndex);
+	}
+
+	private static int indexOf(List<Diagram> diagrams, UUID id) {
+		for (int i = 0; i < diagrams.size(); i++) {
+			if (diagrams.get(i).getId().equals(id)) {
+				return i;
+			}
+		}
+		throw new AssertionError("Diagram not found in list: " + id);
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Diagram`/`Revision` JPA entities, their Spring Data repositories, and `DiagramService` — the persistence/service seam shared by REST (#7/#8) and MCP (#10).
- `id`, `shareToken`, `createdAt` are DB-generated (`insertable = false` + `@Generated(event = INSERT)`); `updatedAt` is DB-defaulted on insert but explicitly bumped by the service on every `update`.
- `layout` is `Map<String, Position>` mapped via `@JdbcTypeCode(SqlTypes.JSON)`, matching the JSONB column from #5.
- `update()` snapshots the pre-write `content`/`layout` into a `Revision` only when content or layout actually changes (title-only updates append no Revision), and is plain last-write-wins per ADR-0006.
- `getById` / `getByShareToken` take distinct `UUID`-typed params per ADR-0008, so a shareToken passed to `getById` naturally 404s via `DiagramNotFoundException` rather than silently matching.
- Made `AbstractIntegrationTest` `public` (was package-private) so `DiagramServiceTest` can extend it from the new `diagram` subpackage.

## Test plan
- [x] `mvn verify` in the project's Testcontainers-enabled Docker setup — 19 tests pass (11 new in `DiagramServiceTest`, covering create/getById/getByShareToken/update/delete/listAll ordering per the issue's acceptance criteria), plus existing Migration/LayoutMigration/ApplicationContext tests unaffected.
- [x] Confirmed `DiagramService` has no `@RestController`/web imports — service layer only, no REST or MCP code in this PR.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w