### PR TITLE
Add admin REST endpoints for the Dashboard (list/create/delete)

### DIFF
--- a/backend/src/main/java/dev/omnidiagram/backend/api/AdminDiagramController.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/api/AdminDiagramController.java
@@ -1,0 +1,50 @@
+package dev.omnidiagram.backend.api;
+
+import dev.omnidiagram.backend.diagram.Diagram;
+import dev.omnidiagram.backend.diagram.DiagramService;
+import dev.omnidiagram.backend.diagram.StarterContent;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/diagrams")
+public class AdminDiagramController {
+
+	private static final String DEFAULT_TITLE = "Untitled diagram";
+
+	private final DiagramService diagramService;
+
+	public AdminDiagramController(DiagramService diagramService) {
+		this.diagramService = diagramService;
+	}
+
+	@GetMapping
+	public List<DiagramSummary> list() {
+		return diagramService.listAll().stream().map(DiagramSummary::from).toList();
+	}
+
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	public DiagramResponse create(@Valid @RequestBody CreateDiagramRequest request) {
+		String title = (request.title() == null || request.title().isBlank()) ? DEFAULT_TITLE : request.title();
+		Diagram diagram = diagramService.create(request.kind(), title, StarterContent.forKind(request.kind()));
+		return DiagramResponse.from(diagram);
+	}
+
+	@DeleteMapping("/{shareToken}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void delete(@PathVariable UUID shareToken) {
+		Diagram diagram = diagramService.getByShareToken(shareToken);
+		diagramService.delete(diagram.getId());
+	}
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/api/ApiExceptionHandler.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/api/ApiExceptionHandler.java
@@ -4,6 +4,7 @@ import dev.omnidiagram.backend.diagram.DiagramNotFoundException;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -25,5 +26,10 @@ public class ApiExceptionHandler {
 	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
 	public ResponseEntity<Map<String, String>> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", "Invalid " + ex.getName()));
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<Map<String, String>> handleUnreadableBody(HttpMessageNotReadableException ex) {
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", "Malformed request body"));
 	}
 }

--- a/backend/src/main/java/dev/omnidiagram/backend/api/CreateDiagramRequest.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/api/CreateDiagramRequest.java
@@ -1,0 +1,7 @@
+package dev.omnidiagram.backend.api;
+
+import dev.omnidiagram.backend.diagram.DiagramKind;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateDiagramRequest(@NotNull DiagramKind kind, String title) {
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/api/DiagramSummary.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/api/DiagramSummary.java
@@ -1,0 +1,14 @@
+package dev.omnidiagram.backend.api;
+
+import dev.omnidiagram.backend.diagram.Diagram;
+import dev.omnidiagram.backend.diagram.DiagramKind;
+import java.time.Instant;
+import java.util.UUID;
+
+public record DiagramSummary(UUID shareToken, String title, DiagramKind kind, Instant updatedAt) {
+
+	public static DiagramSummary from(Diagram diagram) {
+		return new DiagramSummary(diagram.getShareToken(), diagram.getTitle(), diagram.getKind(),
+				diagram.getUpdatedAt());
+	}
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/diagram/StarterContent.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/diagram/StarterContent.java
@@ -1,0 +1,14 @@
+package dev.omnidiagram.backend.diagram;
+
+public final class StarterContent {
+
+	private StarterContent() {
+	}
+
+	public static String forKind(DiagramKind kind) {
+		return switch (kind) {
+			case SchemaDiagram -> "Table table_name {\n  id integer [primary key]\n}\n";
+			case GenericDiagram -> "flowchart TD\n  Start --> End\n";
+		};
+	}
+}

--- a/backend/src/test/java/dev/omnidiagram/backend/api/AdminDiagramControllerTest.java
+++ b/backend/src/test/java/dev/omnidiagram/backend/api/AdminDiagramControllerTest.java
@@ -1,0 +1,146 @@
+package dev.omnidiagram.backend.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.not;
+
+import dev.omnidiagram.backend.AbstractIntegrationTest;
+import dev.omnidiagram.backend.diagram.Diagram;
+import dev.omnidiagram.backend.diagram.DiagramKind;
+import dev.omnidiagram.backend.diagram.DiagramService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@AutoConfigureMockMvc
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class AdminDiagramControllerTest extends AbstractIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private DiagramService diagramService;
+
+	@Test
+	@Order(1)
+	void getOnAnEmptyDatabaseReturnsEmptyArrayNotNotFound() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/admin/diagrams"))
+				.andExpect(MockMvcResultMatchers.status().isOk())
+				.andExpect(MockMvcResultMatchers.jsonPath("$").isArray())
+				.andExpect(MockMvcResultMatchers.jsonPath("$").isEmpty());
+	}
+
+	@Test
+	@Order(2)
+	void getReturnsAllDiagramsOrderedByUpdatedAtDescending() throws Exception {
+		Diagram first = diagramService.create(DiagramKind.GenericDiagram, "First", "flowchart TD");
+		Diagram second = diagramService.create(DiagramKind.GenericDiagram, "Second", "flowchart TD");
+		diagramService.update(first.getId(), null, "flowchart LR", null);
+
+		String body = mockMvc.perform(MockMvcRequestBuilders.get("/api/admin/diagrams"))
+				.andExpect(MockMvcResultMatchers.status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+		int firstIndex = body.indexOf(first.getShareToken().toString());
+		int secondIndex = body.indexOf(second.getShareToken().toString());
+		assertThat(firstIndex).isGreaterThanOrEqualTo(0);
+		assertThat(secondIndex).isGreaterThanOrEqualTo(0);
+		assertThat(firstIndex).isLessThan(secondIndex);
+	}
+
+	@Test
+	@Order(3)
+	void getItemsCarryNoContentAndNoId() throws Exception {
+		diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/admin/diagrams"))
+				.andExpect(MockMvcResultMatchers.status().isOk())
+				.andExpect(MockMvcResultMatchers.jsonPath("$[0].content").doesNotExist())
+				.andExpect(MockMvcResultMatchers.jsonPath("$[0].id").doesNotExist());
+	}
+
+	@Test
+	@Order(4)
+	void postWithSchemaDiagramKindReturns201PersistsAndSeedsDbmlStarterContent() throws Exception {
+		String response = mockMvc
+				.perform(MockMvcRequestBuilders.post("/api/admin/diagrams")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content("{\"kind\":\"SchemaDiagram\",\"title\":\"Orders\"}"))
+				.andExpect(MockMvcResultMatchers.status().isCreated())
+				.andExpect(MockMvcResultMatchers.jsonPath("$.content").value(containsString("Table")))
+				.andReturn().getResponse().getContentAsString();
+
+		assertThat(response).contains("Orders");
+	}
+
+	@Test
+	@Order(5)
+	void postWithGenericDiagramKindSeedsMermaidStarterContent() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/admin/diagrams")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content("{\"kind\":\"GenericDiagram\"}"))
+				.andExpect(MockMvcResultMatchers.status().isCreated())
+				.andExpect(MockMvcResultMatchers.jsonPath("$.content").value(containsString("flowchart")));
+	}
+
+	@Test
+	@Order(6)
+	void postWithAMissingKindReturns400() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/admin/diagrams")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content("{\"title\":\"No kind\"}"))
+				.andExpect(MockMvcResultMatchers.status().isBadRequest())
+				.andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+	}
+
+	@Test
+	@Order(7)
+	void postWithAnUnrecognisedKindReturns400() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/admin/diagrams")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content("{\"kind\":\"Nonsense\"}"))
+				.andExpect(MockMvcResultMatchers.status().isBadRequest())
+				.andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+	}
+
+	@Test
+	@Order(8)
+	void postWithNoTitleStillSucceedsWithADefaultTitle() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/admin/diagrams")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content("{\"kind\":\"GenericDiagram\"}"))
+				.andExpect(MockMvcResultMatchers.status().isCreated())
+				.andExpect(MockMvcResultMatchers.jsonPath("$.title").value(not(emptyOrNullString())));
+	}
+
+	@Test
+	@Order(9)
+	void deleteReturns204RemovesTheDiagramAndCascadesItsRevisions() throws Exception {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "To delete", "flowchart TD");
+		diagramService.update(diagram.getId(), null, "flowchart LR", null);
+
+		mockMvc.perform(MockMvcRequestBuilders.delete("/api/admin/diagrams/{shareToken}", diagram.getShareToken()))
+				.andExpect(MockMvcResultMatchers.status().isNoContent());
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/diagrams/{shareToken}", diagram.getShareToken()))
+				.andExpect(MockMvcResultMatchers.status().isNotFound());
+	}
+
+	@Test
+	@Order(10)
+	void deleteOnAnUnknownTokenReturns404() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.delete("/api/admin/diagrams/{shareToken}", UUID.randomUUID()))
+				.andExpect(MockMvcResultMatchers.status().isNotFound());
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `GET/POST /api/admin/diagrams` and `DELETE /api/admin/diagrams/{shareToken}` under their own `/api/admin/` prefix, per ADR-0010 (Cloudflare Access can only match hostname+path, not HTTP method, so listing/create/delete can't share the public prefix).
- `DiagramSummary` is a lean dashboard-row projection (no `content`, no `id`).
- `StarterContent` centralizes the seeded content per `DiagramKind` (a minimal `Table` stub for SchemaDiagram, a minimal `flowchart TD` for GenericDiagram) as its own small testable unit, per dashboard-ux.md's "kind only, then an empty editor" creation flow — `content` is intentionally not accepted in the create request.
- `CreateDiagramRequest.kind` is `@NotNull`; a missing title falls back to "Untitled diagram".
- Extended `ApiExceptionHandler` (from #7) with an `HttpMessageNotReadableException` handler → 400 JSON, needed so an unrecognized `kind` string (a Jackson deserialization failure, not a bean-validation failure) still returns JSON 400 rather than falling through to Boot's default error handling.
- No auth/session code added — enforcement is entirely Cloudflare's, per ADR-0010's explicit instruction not to add app-side auth here.

## Test plan
- [x] `mvn verify` — 39 tests pass total, 10 new in `AdminDiagramControllerTest` covering every acceptance case: empty-DB list returns `[]` not 404, ordering, no `content`/`id` leakage, SchemaDiagram/GenericDiagram starter-content seeding, missing/unrecognized `kind` → 400, missing title → default title, delete → 204 + cascades Revisions + the diagram then 404s on the public GET route, delete-unknown-token → 404.
- [x] Because integration tests in this repo share one Postgres container per test class (no per-test transaction rollback), `AdminDiagramControllerTest` uses `@TestMethodOrder(OrderAnnotation.class)` with the empty-database assertion pinned to run first — otherwise it would be order-dependent on a shared, gradually-populated database.
- [x] Confirmed every route sits under `/api/admin/` and no admin behavior leaked onto `/api/diagrams/*`.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w