### PR TITLE
Add Revision history and revert API

### DIFF
--- a/backend/src/main/java/dev/omnidiagram/backend/api/RevisionController.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/api/RevisionController.java
@@ -1,0 +1,35 @@
+package dev.omnidiagram.backend.api;
+
+import dev.omnidiagram.backend.diagram.Diagram;
+import dev.omnidiagram.backend.diagram.DiagramService;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/diagrams/{shareToken}/revisions")
+public class RevisionController {
+
+	private final DiagramService diagramService;
+
+	public RevisionController(DiagramService diagramService) {
+		this.diagramService = diagramService;
+	}
+
+	@GetMapping
+	public List<RevisionSummary> list(@PathVariable UUID shareToken) {
+		Diagram diagram = diagramService.getByShareToken(shareToken);
+		return diagramService.listRevisions(diagram.getId()).stream().map(RevisionSummary::from).toList();
+	}
+
+	@PostMapping("/{id}/revert")
+	public DiagramResponse revert(@PathVariable UUID shareToken, @PathVariable UUID id) {
+		Diagram diagram = diagramService.getByShareToken(shareToken);
+		Diagram reverted = diagramService.revertTo(diagram.getId(), id);
+		return DiagramResponse.from(reverted);
+	}
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/api/RevisionSummary.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/api/RevisionSummary.java
@@ -1,0 +1,16 @@
+package dev.omnidiagram.backend.api;
+
+import dev.omnidiagram.backend.diagram.Revision;
+import java.time.Instant;
+import java.util.UUID;
+
+public record RevisionSummary(UUID id, Instant createdAt, String contentPreview) {
+
+	private static final int PREVIEW_LENGTH = 120;
+
+	public static RevisionSummary from(Revision revision) {
+		String content = revision.getContent();
+		String preview = content.length() > PREVIEW_LENGTH ? content.substring(0, PREVIEW_LENGTH) : content;
+		return new RevisionSummary(revision.getId(), revision.getCreatedAt(), preview);
+	}
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/diagram/DiagramService.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/diagram/DiagramService.java
@@ -63,6 +63,26 @@ public class DiagramService {
 		diagramRepository.deleteById(id);
 	}
 
+	@Transactional(readOnly = true)
+	public List<Revision> listRevisions(UUID diagramId) {
+		return revisionRepository.findAllByDiagramIdOrderByCreatedAtDesc(diagramId);
+	}
+
+	public Diagram revertTo(UUID diagramId, UUID revisionId) {
+		Diagram diagram = findDiagram(diagramId);
+		Revision revision = revisionRepository.findById(revisionId)
+				.filter(candidate -> candidate.getDiagramId().equals(diagramId))
+				.orElseThrow(() -> new DiagramNotFoundException(revisionId));
+
+		revisionRepository.save(new Revision(diagram.getId(), diagram.getContent(), diagram.getLayout()));
+
+		diagram.setContent(revision.getContent());
+		diagram.setLayout(revision.getLayout());
+		diagram.setUpdatedAt(Instant.now());
+
+		return diagramRepository.save(diagram);
+	}
+
 	private Diagram findDiagram(UUID id) {
 		return diagramRepository.findById(id).orElseThrow(() -> new DiagramNotFoundException(id));
 	}

--- a/backend/src/test/java/dev/omnidiagram/backend/api/RevisionControllerTest.java
+++ b/backend/src/test/java/dev/omnidiagram/backend/api/RevisionControllerTest.java
@@ -1,0 +1,93 @@
+package dev.omnidiagram.backend.api;
+
+import dev.omnidiagram.backend.AbstractIntegrationTest;
+import dev.omnidiagram.backend.diagram.Diagram;
+import dev.omnidiagram.backend.diagram.DiagramKind;
+import dev.omnidiagram.backend.diagram.DiagramService;
+import dev.omnidiagram.backend.diagram.Revision;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@AutoConfigureMockMvc
+class RevisionControllerTest extends AbstractIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private DiagramService diagramService;
+
+	@Test
+	void getOnADiagramWithThreeSavesReturnsThreeEntriesNewestFirst() throws Exception {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+		diagramService.update(diagram.getId(), null, "flowchart LR", null);
+		diagramService.update(diagram.getId(), null, "flowchart RL", null);
+		diagramService.update(diagram.getId(), null, "flowchart BT", null);
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/diagrams/{shareToken}/revisions", diagram.getShareToken()))
+				.andExpect(MockMvcResultMatchers.status().isOk())
+				.andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(3))
+				.andExpect(MockMvcResultMatchers.jsonPath("$[0].contentPreview").value("flowchart RL"))
+				.andExpect(MockMvcResultMatchers.jsonPath("$[2].contentPreview").value("flowchart TD"));
+	}
+
+	@Test
+	void getOnANeverEditedDiagramReturnsEmptyArray() throws Exception {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/diagrams/{shareToken}/revisions", diagram.getShareToken()))
+				.andExpect(MockMvcResultMatchers.status().isOk())
+				.andExpect(MockMvcResultMatchers.jsonPath("$").isArray())
+				.andExpect(MockMvcResultMatchers.jsonPath("$").isEmpty());
+	}
+
+	@Test
+	void postRevertReturns200WithTheRestoredContentInTheBody() throws Exception {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+		diagramService.update(diagram.getId(), null, "flowchart LR", null);
+		Revision original = diagramService.listRevisions(diagram.getId()).get(0);
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/diagrams/{shareToken}/revisions/{id}/revert",
+						diagram.getShareToken(), original.getId()))
+				.andExpect(MockMvcResultMatchers.status().isOk())
+				.andExpect(MockMvcResultMatchers.jsonPath("$.content").value("flowchart TD"));
+	}
+
+	@Test
+	void postWithAnUnknownRevisionIdReturns404() throws Exception {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/diagrams/{shareToken}/revisions/{id}/revert",
+						diagram.getShareToken(), UUID.randomUUID()))
+				.andExpect(MockMvcResultMatchers.status().isNotFound());
+	}
+
+	@Test
+	void postUsingAnotherDiagramsRevisionIdReturns404() throws Exception {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+		Diagram other = diagramService.create(DiagramKind.GenericDiagram, "Other", "flowchart LR");
+		diagramService.update(other.getId(), null, "flowchart RL", null);
+		Revision otherRevision = diagramService.listRevisions(other.getId()).get(0);
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/diagrams/{shareToken}/revisions/{id}/revert",
+						diagram.getShareToken(), otherRevision.getId()))
+				.andExpect(MockMvcResultMatchers.status().isNotFound());
+	}
+
+	@Test
+	void unknownShareTokenReturns404OnBothRoutes() throws Exception {
+		UUID unknownToken = UUID.randomUUID();
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/diagrams/{shareToken}/revisions", unknownToken))
+				.andExpect(MockMvcResultMatchers.status().isNotFound());
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/diagrams/{shareToken}/revisions/{id}/revert",
+						unknownToken, UUID.randomUUID()))
+				.andExpect(MockMvcResultMatchers.status().isNotFound());
+	}
+}

--- a/backend/src/test/java/dev/omnidiagram/backend/diagram/DiagramServiceTest.java
+++ b/backend/src/test/java/dev/omnidiagram/backend/diagram/DiagramServiceTest.java
@@ -140,6 +140,75 @@ class DiagramServiceTest extends AbstractIntegrationTest {
 		assertThat(firstIndex).isLessThan(secondIndex);
 	}
 
+	@Test
+	void listRevisionsReturnsNewestFirstAndExcludesOtherDiagramsRevisions() {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+		Diagram other = diagramService.create(DiagramKind.GenericDiagram, "Other", "flowchart TD");
+		diagramService.update(diagram.getId(), null, "flowchart LR", null);
+		diagramService.update(diagram.getId(), null, "flowchart RL", null);
+		diagramService.update(other.getId(), null, "flowchart BT", null);
+
+		List<Revision> revisions = diagramService.listRevisions(diagram.getId());
+
+		assertThat(revisions).hasSize(2);
+		assertThat(revisions.get(0).getContent()).isEqualTo("flowchart LR");
+		assertThat(revisions.get(1).getContent()).isEqualTo("flowchart TD");
+	}
+
+	@Test
+	void revertToRestoresContentAndLayoutTogether() {
+		Diagram diagram = diagramService.create(DiagramKind.SchemaDiagram, "Orders schema",
+				"Table orders { id integer }");
+		diagramService.update(diagram.getId(), null, "Table orders { id integer, name text }",
+				Map.of("orders", new Position(10, 20)));
+		List<Revision> revisions = diagramService.listRevisions(diagram.getId());
+		Revision original = revisions.get(0);
+
+		Diagram reverted = diagramService.revertTo(diagram.getId(), original.getId());
+
+		assertThat(reverted.getContent()).isEqualTo("Table orders { id integer }");
+		assertThat(reverted.getLayout()).isEmpty();
+	}
+
+	@Test
+	void revertToAppendsANewRevisionHoldingThePreRevertContent() {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+		diagramService.update(diagram.getId(), null, "flowchart LR", null);
+		Revision original = diagramService.listRevisions(diagram.getId()).get(0);
+
+		diagramService.revertTo(diagram.getId(), original.getId());
+
+		List<Revision> revisions = diagramService.listRevisions(diagram.getId());
+		assertThat(revisions).hasSize(2);
+		assertThat(revisions.get(0).getContent()).isEqualTo("flowchart LR");
+	}
+
+	@Test
+	void revertingTwiceReturnsToTheIntermediateStateSinceRevertIsNotIdempotent() {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+		diagramService.update(diagram.getId(), null, "flowchart LR", null);
+		Revision original = diagramService.listRevisions(diagram.getId()).get(0);
+
+		Diagram firstRevert = diagramService.revertTo(diagram.getId(), original.getId());
+		assertThat(firstRevert.getContent()).isEqualTo("flowchart TD");
+
+		Revision preFirstRevert = diagramService.listRevisions(diagram.getId()).get(0);
+		Diagram secondRevert = diagramService.revertTo(diagram.getId(), preFirstRevert.getId());
+
+		assertThat(secondRevert.getContent()).isEqualTo("flowchart LR");
+	}
+
+	@Test
+	void revertToWithARevisionIdBelongingToAnotherDiagramThrowsDiagramNotFoundException() {
+		Diagram diagram = diagramService.create(DiagramKind.GenericDiagram, "Flow", "flowchart TD");
+		Diagram other = diagramService.create(DiagramKind.GenericDiagram, "Other", "flowchart LR");
+		diagramService.update(other.getId(), null, "flowchart RL", null);
+		Revision otherRevision = diagramService.listRevisions(other.getId()).get(0);
+
+		assertThatThrownBy(() -> diagramService.revertTo(diagram.getId(), otherRevision.getId()))
+				.isInstanceOf(DiagramNotFoundException.class);
+	}
+
 	private static int indexOf(List<Diagram> diagrams, UUID id) {
 		for (int i = 0; i < diagrams.size(); i++) {
 			if (diagrams.get(i).getId().equals(id)) {


### PR DESCRIPTION
## Summary
- Adds `GET /api/diagrams/{shareToken}/revisions` (list, newest-first, `RevisionSummary` with a ~120-char `contentPreview`) and `POST /api/diagrams/{shareToken}/revisions/{id}/revert` — public, alongside the editor routes, since a share link already grants edit rights per ADR-0001.
- `DiagramService.revertTo` is a **forward write**: it snapshots the Diagram's current content/layout as a new Revision, then overwrites the Diagram with the target Revision's values. Nothing is destroyed, history only grows, and reverting a revert is a normal write (not idempotent, restores the intermediate state).
- `revertTo` rejects a revision id belonging to a different Diagram — it 404s (`DiagramNotFoundException`) rather than cross-diagram copying content.
- Skipped the optional `GET .../revisions/{id}` (full content) endpoint the issue calls out as needed only if Phase D's preview pane needs it — not listed under this issue's Files/Tests to change, so left out until that's actually needed.

## Test plan
- [x] `mvn verify` — 50 tests pass total. 5 new in `DiagramServiceTest` (newest-first + diagram isolation, content+layout restore together, revert appends rather than rewinds, double-revert lands on the intermediate state, cross-diagram revision id 404s) and 6 new in `RevisionControllerTest` (three-saves-three-entries newest-first, never-edited returns `[]`, revert 200 with restored content, unknown revision id 404, another diagram's revision id 404, unknown shareToken 404 on both routes).
- [x] Confirmed no Revision row is ever updated or deleted by this code — `revertTo` only ever calls `revisionRepository.save(new Revision(...))` to append.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w