### PR TITLE
Fix Revision doc claim and drop unbacked id field found by plan scrutiny

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -30,7 +30,7 @@ Returns the created Diagram (same shape as `get_diagram`).
 
 Partial update — omit a field to leave it unchanged. `format` follows the same rule as `create_diagram` when `content` is provided for a SchemaDiagram.
 
-Last-write-wins: no revision/version check, no conflict error. Every call still creates a new Revision snapshot.
+Last-write-wins: no revision/version check, no conflict error. A new Revision snapshot is created whenever `content` or layout changes; a title-only update creates none (a Revision captures content and layout, per [CONTEXT.md](../CONTEXT.md)).
 
 ## `export_diagram(id, format)`
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -21,7 +21,7 @@ export default function Dashboard() {
         ) : (
           <div className="rounded-lg border border-black/10 dark:border-white/10">
             {diagrams.map((diagram) => (
-              <DiagramRow key={diagram.id} diagram={diagram} />
+              <DiagramRow key={diagram.shareToken} diagram={diagram} />
             ))}
           </div>
         )}

--- a/frontend/src/lib/placeholder-diagrams.ts
+++ b/frontend/src/lib/placeholder-diagrams.ts
@@ -5,7 +5,6 @@ import { Diagram } from "./types";
 // against /api/diagrams once that lands.
 export const placeholderDiagrams: Diagram[] = [
   {
-    id: "1e6a0e2e-2f1a-4b8e-9c1a-000000000001",
     shareToken: "tt1-schema-orders",
     title: "Orders schema",
     kind: "SchemaDiagram",
@@ -25,7 +24,6 @@ Ref: orders.customer_id > customers.id
     updatedAt: "2026-08-15T09:30:00Z",
   },
   {
-    id: "1e6a0e2e-2f1a-4b8e-9c1a-000000000002",
     shareToken: "tt2-checkout-flow",
     title: "Checkout flow",
     kind: "GenericDiagram",

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,7 +1,6 @@
 export type DiagramKind = "SchemaDiagram" | "GenericDiagram";
 
 export interface Diagram {
-  id: string;
   shareToken: string;
   title: string;
   kind: DiagramKind;


### PR DESCRIPTION
## Summary
- `docs/mcp-tools.md` claimed every `update_diagram` call creates a Revision; `DiagramService` only does so when `content`/`layout` change (matches `CONTEXT.md`'s Revision definition, and is locked in by `DiagramServiceTest.updateWithOnlyATitleAppendsNoRevision`). Doc corrected to match.
- Removed `Diagram.id` from the frontend (`types.ts`, `placeholder-diagrams.ts`) — no backend REST response ever exposes it (ADR-0008: REST is shareToken-only), and it was already misused as a React `key` in `page.tsx`, swapped to `shareToken`.

Found via a `/scrutinize` pass over the whole project plan; a third finding (issue #18's Export/Import plan calling the Caddy-blocked `/api/internal/dbml/*` route from the browser) was fixed by editing issue #18's body directly rather than code, since #18 hasn't been implemented yet.

## Test plan
- [x] `npx next typegen && npx tsc --noEmit` — passes, no type errors after dropping `id`
- [x] `npm run lint` — passes
- [x] `npm run test` — 3/3 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w