### PR TITLE
Add DBML<->SQL conversion routes in Next.js

### DIFF
--- a/docs/adr/0009-dbml-sql-conversion-lives-in-nextjs.md
+++ b/docs/adr/0009-dbml-sql-conversion-lives-in-nextjs.md
@@ -9,3 +9,5 @@ So the conversion runs where `@dbml/core` already runs. The Next.js app exposes 
 ## Consequences
 
 The backend now depends on the frontend at runtime for SQL import/export, inverting the usual direction — if the frontend container is down, those MCP tools fail while the rest of the API keeps working. The `/api/internal/*` prefix must never be exposed through Caddy, or anyone could reach it from the internet. Conversion also costs an extra internal HTTP hop, and errors from `@dbml/core` have to be translated into meaningful MCP tool errors across that boundary.
+
+`sql-sqlite` turned out not to be deliverable: `@dbml/core` (through the latest published 10.1.1) silently returns an empty string for the `sqlite` dialect on both import and export, rather than converting or throwing. There is no newer major version that adds it. `/api/internal/dbml/*` and `export_diagram` therefore only support `postgres`, `mysql`, and `mssql` — see [docs/mcp-tools.md](../mcp-tools.md).

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -35,10 +35,12 @@ Last-write-wins: no revision/version check, no conflict error. A new Revision sn
 ## `export_diagram(id, format)`
 
 `format` depends on `kind`:
-- SchemaDiagram: `"dbml" | "sql-postgres" | "sql-mysql" | "sql-sqlserver" | "sql-sqlite"`
+- SchemaDiagram: `"dbml" | "sql-postgres" | "sql-mysql" | "sql-sqlserver"`
 - GenericDiagram: `"mermaid"`
 
 Always returns content inline in the response as plain text. No download URLs.
+
+`sql-sqlite` is deliberately absent: `@dbml/core`, the library that implements the conversion (see below), silently returns an empty string for the `sqlite` dialect on both import and export instead of converting or erroring, in every published version through 10.1.1. It is not a usable dialect, so `create_diagram`/`update_diagram`/`export_diagram` only accept SQL for postgres, mysql, and mssql.
 
 **Text only.** Image formats (`png`, `svg`) are deliberately absent: both SchemaDiagram (react-flow) and GenericDiagram (Mermaid) need a real DOM to render, so serving them from MCP would mean running headless Chrome in the backend. Image export is a UI feature instead — the browser has already rendered the diagram, so it exports client-side at no extra cost.
 

--- a/frontend/src/app/api/internal/dbml/from-sql/route.ts
+++ b/frontend/src/app/api/internal/dbml/from-sql/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { DbmlConversionError, sqlToDbml } from "@/lib/dbml";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  let body: { sql?: unknown; dialect?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Request body must be valid JSON" }, { status: 400 });
+  }
+
+  const { sql, dialect } = body;
+  if (typeof sql !== "string" || typeof dialect !== "string") {
+    return NextResponse.json({ error: "Both sql and dialect are required" }, { status: 400 });
+  }
+
+  try {
+    const dbml = sqlToDbml(sql, dialect);
+    return NextResponse.json({ dbml });
+  } catch (err) {
+    if (err instanceof DbmlConversionError) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+    return NextResponse.json({ error: "Internal conversion error" }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/internal/dbml/route.test.ts
+++ b/frontend/src/app/api/internal/dbml/route.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { POST as fromSql } from "./from-sql/route";
+import { POST as toSql } from "./to-sql/route";
+
+function postJson(url: string, body: unknown) {
+  return new Request(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const CREATE_USERS_SQL =
+  "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255));";
+
+describe("POST /api/internal/dbml/from-sql", () => {
+  it("returns 200 with { dbml } for valid input", async () => {
+    const res = await fromSql(
+      postJson("http://localhost/api/internal/dbml/from-sql", {
+        sql: CREATE_USERS_SQL,
+        dialect: "postgres",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.dbml).toContain("users");
+  });
+
+  it("returns 400 with an error field for malformed SQL", async () => {
+    const res = await fromSql(
+      postJson("http://localhost/api/internal/dbml/from-sql", {
+        sql: "CREATE TABLE users (id INT PRIMARY",
+        dialect: "postgres",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBeTypeOf("string");
+  });
+
+  it("returns 400 when a required field is missing", async () => {
+    const res = await fromSql(
+      postJson("http://localhost/api/internal/dbml/from-sql", { sql: CREATE_USERS_SQL }),
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBeTypeOf("string");
+  });
+
+  // Next.js's route dispatcher returns 405 Method Not Allowed for any HTTP
+  // method the route file doesn't export (see docs/01-app/.../route.md,
+  // "Supported HTTP Methods"). This route only exports POST.
+  it("only implements POST, so Next.js dispatches 405 for other methods", async () => {
+    const routeModule: Record<string, unknown> = await import("./from-sql/route");
+    expect(routeModule.POST).toBeTypeOf("function");
+    expect(routeModule.GET).toBeUndefined();
+  });
+});
+
+describe("POST /api/internal/dbml/to-sql", () => {
+  it("returns 200 with { sql } for valid input", async () => {
+    const res = await toSql(
+      postJson("http://localhost/api/internal/dbml/to-sql", {
+        dbml: 'Table users {\n  id int [pk]\n  name varchar\n}',
+        dialect: "postgres",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.sql.toUpperCase()).toContain("CREATE TABLE");
+  });
+
+  it("returns 400 with an error field for malformed DBML", async () => {
+    const res = await toSql(
+      postJson("http://localhost/api/internal/dbml/to-sql", {
+        dbml: "Table users {",
+        dialect: "postgres",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBeTypeOf("string");
+  });
+
+  it("returns 400 when a required field is missing", async () => {
+    const res = await toSql(
+      postJson("http://localhost/api/internal/dbml/to-sql", { dialect: "postgres" }),
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBeTypeOf("string");
+  });
+
+  it("only implements POST, so Next.js dispatches 405 for other methods", async () => {
+    const routeModule: Record<string, unknown> = await import("./to-sql/route");
+    expect(routeModule.POST).toBeTypeOf("function");
+    expect(routeModule.GET).toBeUndefined();
+  });
+});

--- a/frontend/src/app/api/internal/dbml/to-sql/route.ts
+++ b/frontend/src/app/api/internal/dbml/to-sql/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { DbmlConversionError, dbmlToSql } from "@/lib/dbml";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  let body: { dbml?: unknown; dialect?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Request body must be valid JSON" }, { status: 400 });
+  }
+
+  const { dbml, dialect } = body;
+  if (typeof dbml !== "string" || typeof dialect !== "string") {
+    return NextResponse.json({ error: "Both dbml and dialect are required" }, { status: 400 });
+  }
+
+  try {
+    const sql = dbmlToSql(dbml, dialect);
+    return NextResponse.json({ sql });
+  } catch (err) {
+    if (err instanceof DbmlConversionError) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+    return NextResponse.json({ error: "Internal conversion error" }, { status: 500 });
+  }
+}

--- a/frontend/src/lib/dbml.test.ts
+++ b/frontend/src/lib/dbml.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { DbmlConversionError, dbmlToSql, sqlToDbml } from "./dbml";
+
+const CREATE_USERS_SQL =
+  "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255));";
+
+describe("sqlToDbml", () => {
+  it("converts a valid Postgres CREATE TABLE into DBML containing the table and columns", () => {
+    const dbml = sqlToDbml(CREATE_USERS_SQL, "postgres");
+    expect(dbml).toContain("users");
+    expect(dbml).toContain("id");
+    expect(dbml).toContain("name");
+  });
+
+  it("throws a translated error carrying line information for invalid SQL", () => {
+    expect(() => sqlToDbml("CREATE TABLE users (id INT PRIMARY", "postgres")).toThrow(
+      DbmlConversionError,
+    );
+    try {
+      sqlToDbml("CREATE TABLE users (id INT PRIMARY", "postgres");
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(DbmlConversionError);
+      expect((err as Error).message).toMatch(/line \d+/i);
+    }
+  });
+
+  it("throws for an unknown dialect", () => {
+    expect(() => sqlToDbml(CREATE_USERS_SQL, "sqlite")).toThrow(DbmlConversionError);
+    expect(() => sqlToDbml(CREATE_USERS_SQL, "made-up")).toThrow(/Unknown dialect/);
+  });
+
+  it("throws rather than returning empty output for empty input", () => {
+    expect(() => sqlToDbml("", "postgres")).toThrow(DbmlConversionError);
+    expect(() => sqlToDbml("   ", "postgres")).toThrow(DbmlConversionError);
+  });
+});
+
+describe("dbmlToSql", () => {
+  it("converts DBML back to SQL", () => {
+    const dbml = sqlToDbml(CREATE_USERS_SQL, "postgres");
+    const sql = dbmlToSql(dbml, "postgres");
+    expect(sql).toContain("users");
+    expect(sql.toUpperCase()).toContain("CREATE TABLE");
+  });
+
+  it("round trips DBML -> SQL -> DBML preserving table and column names", () => {
+    const dbml = sqlToDbml(CREATE_USERS_SQL, "postgres");
+    const sql = dbmlToSql(dbml, "postgres");
+    const roundTripped = sqlToDbml(sql, "postgres");
+    expect(roundTripped).toContain("users");
+    expect(roundTripped).toContain("id");
+    expect(roundTripped).toContain("name");
+  });
+
+  it("produces non-empty, distinct SQL per export dialect for the same input", () => {
+    const dbml = sqlToDbml(CREATE_USERS_SQL, "postgres");
+    const outputs = ["postgres", "mysql", "mssql"].map((dialect) => dbmlToSql(dbml, dialect));
+    for (const sql of outputs) {
+      expect(sql.length).toBeGreaterThan(0);
+    }
+    expect(new Set(outputs).size).toBe(outputs.length);
+  });
+
+  it("throws a translated error for invalid DBML", () => {
+    expect(() => dbmlToSql("Table users {", "postgres")).toThrow(DbmlConversionError);
+    try {
+      dbmlToSql("Table users {", "postgres");
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(DbmlConversionError);
+    }
+  });
+
+  it("throws for an unknown dialect", () => {
+    const dbml = sqlToDbml(CREATE_USERS_SQL, "postgres");
+    expect(() => dbmlToSql(dbml, "sqlite")).toThrow(DbmlConversionError);
+    expect(() => dbmlToSql(dbml, "made-up")).toThrow(/Unknown dialect/);
+  });
+
+  it("throws rather than returning empty output for empty input", () => {
+    expect(() => dbmlToSql("", "postgres")).toThrow(DbmlConversionError);
+    expect(() => dbmlToSql("   ", "postgres")).toThrow(DbmlConversionError);
+  });
+});

--- a/frontend/src/lib/dbml.ts
+++ b/frontend/src/lib/dbml.ts
@@ -1,0 +1,75 @@
+import { importer, exporter } from "@dbml/core";
+
+/**
+ * Dialects @dbml/core actually supports for SQL<->DBML conversion in this
+ * installed version (10.1.x). "sqlite" is intentionally excluded: the
+ * library silently returns an empty string for it instead of converting or
+ * throwing, on both import and export, so it is not a usable dialect.
+ */
+const SQL_IMPORT_DIALECTS = ["postgres", "mysql", "mssql"] as const;
+const SQL_EXPORT_DIALECTS = ["postgres", "mysql", "mssql"] as const;
+
+export type SqlImportDialect = (typeof SQL_IMPORT_DIALECTS)[number];
+export type SqlExportDialect = (typeof SQL_EXPORT_DIALECTS)[number];
+
+export class DbmlConversionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DbmlConversionError";
+  }
+}
+
+interface CompilerDiagLike {
+  message?: string;
+  text?: string;
+  location?: { start?: { line?: number } };
+}
+
+function isDiagCarrier(err: unknown): err is { diags: CompilerDiagLike[] } {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    Array.isArray((err as { diags?: unknown }).diags)
+  );
+}
+
+function describeParseError(err: unknown): string {
+  if (isDiagCarrier(err) && err.diags.length > 0) {
+    const diag = err.diags[0];
+    const text = diag.message ?? diag.text ?? "invalid input";
+    const line = diag.location?.start?.line;
+    return line != null ? `Parse error at line ${line}: ${text}` : `Parse error: ${text}`;
+  }
+  if (err instanceof Error) {
+    return `Parse error: ${err.message}`;
+  }
+  return "Parse error: invalid input";
+}
+
+export function sqlToDbml(sql: string, dialect: string): string {
+  if (!sql.trim()) {
+    throw new DbmlConversionError("SQL input must not be empty");
+  }
+  if (!(SQL_IMPORT_DIALECTS as readonly string[]).includes(dialect)) {
+    throw new DbmlConversionError(`Unknown dialect: ${dialect}`);
+  }
+  try {
+    return importer.import(sql, dialect as SqlImportDialect);
+  } catch (err) {
+    throw new DbmlConversionError(describeParseError(err));
+  }
+}
+
+export function dbmlToSql(dbml: string, dialect: string): string {
+  if (!dbml.trim()) {
+    throw new DbmlConversionError("DBML input must not be empty");
+  }
+  if (!(SQL_EXPORT_DIALECTS as readonly string[]).includes(dialect)) {
+    throw new DbmlConversionError(`Unknown dialect: ${dialect}`);
+  }
+  try {
+    return exporter.export(dbml, dialect as SqlExportDialect);
+  } catch (err) {
+    throw new DbmlConversionError(describeParseError(err));
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #11.
- New `frontend/src/lib/dbml.ts` wraps `@dbml/core`'s `importer`/`exporter` with `sqlToDbml`/`dbmlToSql`, translating parse errors into a `DbmlConversionError` carrying line info. No Next.js imports, so it's unit-testable without HTTP.
- New routes `POST /api/internal/dbml/from-sql` and `POST /api/internal/dbml/to-sql`, both `force-dynamic`. Malformed/unknown-dialect input → 400 with `{ error }`; unexpected failures → 500 generic message (never a raw stack trace, since the backend will surface these to MCP callers per #12).
- The existing `Caddyfile` guard (404 for `/api/internal/*`) is unchanged and still in place — these routes stay internal to the compose network.

## Deviation from the issue spec: no `sqlite`
While implementing, I found the installed `@dbml/core@10.1.0` silently returns an **empty string** for the `sqlite` dialect on both import and export — no error, just empty output. I checked the latest published version (10.1.1) and it behaves identically; there's no newer major version. Confirmed with the user directly (not something I want to guess on for a shipped feature): decision was to drop `sqlite` from both dialect lists rather than ship a dialect that silently produces garbage, and update the docs to match. `docs/mcp-tools.md` and `docs/adr/0009` are updated accordingly. Import/export now support `postgres | mysql | mssql` only.

## Test plan
- [x] `npm run test` — 21/21 passing (`dbml.test.ts`: valid SQL→DBML conversion, DBML→SQL→DBML round trip preserves table/column names, each export dialect produces non-empty distinct SQL, invalid SQL/DBML throw `DbmlConversionError` with line info, unknown dialect throws, empty input throws; `route.test.ts`: 200 with `{dbml}`/`{sql}`, 400 on malformed input, 400 on missing required field, and a check that only `POST` is exported so Next.js's router 405s any other method)
- [x] `npm run build` — passes; route table confirms both routes are `ƒ` (dynamic), not statically optimized
- [x] `npm run lint` — clean
- [x] `frontend/src/lib/dbml.ts` has zero Next.js imports (plain TS)
- [ ] Live Caddy 404 curl check from the issue's "How to verify" was **not** re-run — it requires bringing up the full docker-compose stack, and the `Caddyfile` itself is unchanged by this PR (the guard predates it and was verified when the file was added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w