### PR TITLE
Wire backend to the conversion service for SQL import/export

### DIFF
--- a/backend/src/main/java/dev/omnidiagram/backend/conversion/ConversionClientConfig.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/conversion/ConversionClientConfig.java
@@ -1,0 +1,21 @@
+package dev.omnidiagram.backend.conversion;
+
+import java.time.Duration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class ConversionClientConfig {
+
+	private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+	@Bean
+	RestClient.Builder conversionRestClientBuilder() {
+		SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+		requestFactory.setConnectTimeout(TIMEOUT);
+		requestFactory.setReadTimeout(TIMEOUT);
+		return RestClient.builder().requestFactory(requestFactory);
+	}
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/conversion/ConversionException.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/conversion/ConversionException.java
@@ -1,0 +1,12 @@
+package dev.omnidiagram.backend.conversion;
+
+public class ConversionException extends RuntimeException {
+
+	public ConversionException(String message) {
+		super(message);
+	}
+
+	public ConversionException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/conversion/DbmlConversionClient.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/conversion/DbmlConversionClient.java
@@ -1,0 +1,74 @@
+package dev.omnidiagram.backend.conversion;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+/**
+ * The injected {@link RestClient.Builder} is expected to already carry the
+ * connect/read timeout (see {@link ConversionClientConfig}) so that tests can
+ * bind a {@code MockRestServiceServer} to a plain builder without this class
+ * overwriting its request factory.
+ */
+@Component
+public class DbmlConversionClient {
+
+	private final RestClient restClient;
+	private final String frontendUrl;
+
+	public DbmlConversionClient(RestClient.Builder builder,
+			@Value("${omnidiagram.frontend-url}") String frontendUrl) {
+		this.frontendUrl = frontendUrl;
+		this.restClient = builder.baseUrl(frontendUrl).build();
+	}
+
+	public String sqlToDbml(String sql, String dialect) {
+		return post("/api/internal/dbml/from-sql", new FromSqlRequest(sql, dialect), FromSqlResponse.class).dbml();
+	}
+
+	public String dbmlToSql(String dbml, String dialect) {
+		return post("/api/internal/dbml/to-sql", new ToSqlRequest(dbml, dialect), ToSqlResponse.class).sql();
+	}
+
+	private <T> T post(String path, Object requestBody, Class<T> responseType) {
+		try {
+			return restClient.post().uri(path).body(requestBody).retrieve().body(responseType);
+		}
+		catch (RestClientResponseException ex) {
+			throw new ConversionException(extractErrorMessage(ex));
+		}
+		catch (ResourceAccessException ex) {
+			throw new ConversionException("Conversion service unreachable at " + frontendUrl, ex);
+		}
+	}
+
+	private String extractErrorMessage(RestClientResponseException ex) {
+		try {
+			ErrorResponse error = ex.getResponseBodyAs(ErrorResponse.class);
+			if (error != null && error.error() != null && !error.error().isBlank()) {
+				return error.error();
+			}
+		}
+		catch (RuntimeException ignored) {
+			// response body wasn't the expected { "error": "..." } shape; fall through
+		}
+		return "Conversion service returned " + ex.getStatusCode();
+	}
+
+	private record FromSqlRequest(String sql, String dialect) {
+	}
+
+	private record FromSqlResponse(String dbml) {
+	}
+
+	private record ToSqlRequest(String dbml, String dialect) {
+	}
+
+	private record ToSqlResponse(String sql) {
+	}
+
+	private record ErrorResponse(String error) {
+	}
+}

--- a/backend/src/main/java/dev/omnidiagram/backend/mcp/DiagramTools.java
+++ b/backend/src/main/java/dev/omnidiagram/backend/mcp/DiagramTools.java
@@ -1,10 +1,12 @@
 package dev.omnidiagram.backend.mcp;
 
+import dev.omnidiagram.backend.conversion.DbmlConversionClient;
 import dev.omnidiagram.backend.diagram.Diagram;
 import dev.omnidiagram.backend.diagram.DiagramKind;
 import dev.omnidiagram.backend.diagram.DiagramService;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -15,10 +17,20 @@ public class DiagramTools {
 
 	private static final String DEFAULT_TITLE = "Untitled diagram";
 
-	private final DiagramService diagramService;
+	/**
+	 * Public MCP format names for SQL, mapped to the dialect names the conversion
+	 * service (and @dbml/core underneath it) expects. Used for both import
+	 * (create_diagram/update_diagram) and export.
+	 */
+	private static final Map<String, String> SQL_FORMAT_DIALECTS = Map.of("sql-postgres", "postgres", "sql-mysql",
+			"mysql", "sql-sqlserver", "mssql");
 
-	public DiagramTools(DiagramService diagramService) {
+	private final DiagramService diagramService;
+	private final DbmlConversionClient dbmlConversionClient;
+
+	public DiagramTools(DiagramService diagramService, DbmlConversionClient dbmlConversionClient) {
 		this.diagramService = diagramService;
+		this.dbmlConversionClient = dbmlConversionClient;
 	}
 
 	@Tool(name = "list_diagrams", description = "List every Diagram, no pagination or filtering")
@@ -36,7 +48,8 @@ public class DiagramTools {
 			@ToolParam(description = "SchemaDiagram or GenericDiagram") DiagramKind kind,
 			@ToolParam(description = "Diagram title", required = false) String title,
 			@ToolParam(description = "DBML source for SchemaDiagram, Mermaid source for GenericDiagram") String content,
-			@ToolParam(description = "Required for SchemaDiagram: 'dbml' or 'sql'. Ignored for GenericDiagram.",
+			@ToolParam(
+					description = "Required for SchemaDiagram: 'dbml', 'sql-postgres', 'sql-mysql', or 'sql-sqlserver'. Ignored for GenericDiagram.",
 					required = false) String format) {
 		String resolvedContent = resolveInboundContent(kind, content, format);
 		String resolvedTitle = (title == null || title.isBlank()) ? DEFAULT_TITLE : title;
@@ -48,7 +61,8 @@ public class DiagramTools {
 			@ToolParam(description = "Internal Diagram id") UUID id,
 			@ToolParam(description = "New title", required = false) String title,
 			@ToolParam(description = "New content", required = false) String content,
-			@ToolParam(description = "Required when content is set for a SchemaDiagram: 'dbml' or 'sql'",
+			@ToolParam(
+					description = "Required when content is set for a SchemaDiagram: 'dbml', 'sql-postgres', 'sql-mysql', or 'sql-sqlserver'",
 					required = false) String format) {
 		String resolvedContent = content;
 		if (content != null) {
@@ -61,7 +75,7 @@ public class DiagramTools {
 	@Tool(name = "export_diagram", description = "Export a Diagram's content as plain text")
 	public String exportDiagram(
 			@ToolParam(description = "Internal Diagram id") UUID id,
-			@ToolParam(description = "dbml/sql-postgres/sql-mysql/sql-sqlserver/sql-sqlite for SchemaDiagram, "
+			@ToolParam(description = "dbml/sql-postgres/sql-mysql/sql-sqlserver for SchemaDiagram, "
 					+ "mermaid for GenericDiagram") String format) {
 		Diagram diagram = diagramService.getById(id);
 		return switch (diagram.getKind()) {
@@ -77,22 +91,25 @@ public class DiagramTools {
 		if (format == null) {
 			throw new IllegalArgumentException("format is required for SchemaDiagram");
 		}
-		if (format.equals("sql")) {
-			throw new IllegalArgumentException("SQL import is not yet implemented");
+		if (format.equals("dbml")) {
+			return content;
 		}
-		if (!format.equals("dbml")) {
+		String dialect = SQL_FORMAT_DIALECTS.get(format);
+		if (dialect == null) {
 			throw new IllegalArgumentException("Unsupported format: " + format);
 		}
-		return content;
+		return dbmlConversionClient.sqlToDbml(content, dialect);
 	}
 
 	private String exportSchemaDiagram(Diagram diagram, String format) {
-		return switch (format) {
-			case "dbml" -> diagram.getContent();
-			case "sql-postgres", "sql-mysql", "sql-sqlserver", "sql-sqlite" ->
-					throw new IllegalArgumentException("SQL export is not yet implemented");
-			default -> throw new IllegalArgumentException("Unsupported format for SchemaDiagram: " + format);
-		};
+		if (format.equals("dbml")) {
+			return diagram.getContent();
+		}
+		String dialect = SQL_FORMAT_DIALECTS.get(format);
+		if (dialect == null) {
+			throw new IllegalArgumentException("Unsupported format for SchemaDiagram: " + format);
+		}
+		return dbmlConversionClient.dbmlToSql(diagram.getContent(), dialect);
 	}
 
 	private String exportGenericDiagram(Diagram diagram, String format) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -21,6 +21,9 @@ spring:
 mcp:
   api-key: ${MCP_API_KEY:}
 
+omnidiagram:
+  frontend-url: ${FRONTEND_INTERNAL_URL:http://localhost:3000}
+
 server:
   port: 8080
 

--- a/backend/src/test/java/dev/omnidiagram/backend/conversion/DbmlConversionClientTest.java
+++ b/backend/src/test/java/dev/omnidiagram/backend/conversion/DbmlConversionClientTest.java
@@ -1,0 +1,88 @@
+package dev.omnidiagram.backend.conversion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withException;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class DbmlConversionClientTest {
+
+	private static final String FRONTEND_URL = "http://frontend:3000";
+
+	private final RestClient.Builder builder = RestClient.builder();
+	private final MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+	private final DbmlConversionClient client = new DbmlConversionClient(builder, FRONTEND_URL);
+
+	@Test
+	void sqlToDbmlPostsToTheRightPathWithTheRightBodyAndReturnsTheDbmlField() {
+		server.expect(requestTo(FRONTEND_URL + "/api/internal/dbml/from-sql"))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(jsonPath("$.sql").value("CREATE TABLE users (id INT);"))
+			.andExpect(jsonPath("$.dialect").value("postgres"))
+			.andRespond(withSuccess("{\"dbml\":\"Table users {}\"}", MediaType.APPLICATION_JSON));
+
+		String dbml = client.sqlToDbml("CREATE TABLE users (id INT);", "postgres");
+
+		assertThat(dbml).isEqualTo("Table users {}");
+		server.verify();
+	}
+
+	@Test
+	void dbmlToSqlPostsToTheRightPathWithTheRightBodyForPostgres() {
+		assertDbmlToSqlUsesDialect("postgres");
+	}
+
+	@Test
+	void dbmlToSqlPostsToTheRightPathWithTheRightBodyForMysql() {
+		assertDbmlToSqlUsesDialect("mysql");
+	}
+
+	@Test
+	void dbmlToSqlPostsToTheRightPathWithTheRightBodyForMssql() {
+		assertDbmlToSqlUsesDialect("mssql");
+	}
+
+	private void assertDbmlToSqlUsesDialect(String dialect) {
+		server.expect(requestTo(FRONTEND_URL + "/api/internal/dbml/to-sql"))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(jsonPath("$.dbml").value("Table users {}"))
+			.andExpect(jsonPath("$.dialect").value(dialect))
+			.andRespond(withSuccess("{\"sql\":\"CREATE TABLE users ();\"}", MediaType.APPLICATION_JSON));
+
+		String sql = client.dbmlToSql("Table users {}", dialect);
+
+		assertThat(sql).isEqualTo("CREATE TABLE users ();");
+		server.verify();
+	}
+
+	@Test
+	void a400FromTheConversionServiceBecomesAConversionExceptionCarryingTheReturnedMessage() {
+		server.expect(requestTo(FRONTEND_URL + "/api/internal/dbml/from-sql"))
+			.andRespond(withBadRequest().body("{\"error\":\"Parse error at line 3: expected ')'\"}")
+				.contentType(MediaType.APPLICATION_JSON));
+
+		assertThatThrownBy(() -> client.sqlToDbml("bad sql", "postgres")).isInstanceOf(ConversionException.class)
+			.hasMessage("Parse error at line 3: expected ')'");
+	}
+
+	@Test
+	void aConnectionFailureBecomesAConversionExceptionNamingTheUnreachableServiceNotARawResourceAccessException() {
+		server.expect(requestTo(FRONTEND_URL + "/api/internal/dbml/from-sql"))
+			.andRespond(withException(new IOException("connection refused")));
+
+		assertThatThrownBy(() -> client.sqlToDbml("CREATE TABLE users (id INT);", "postgres"))
+			.isInstanceOf(ConversionException.class)
+			.hasMessageContaining(FRONTEND_URL);
+	}
+}

--- a/backend/src/test/java/dev/omnidiagram/backend/mcp/DiagramToolsTest.java
+++ b/backend/src/test/java/dev/omnidiagram/backend/mcp/DiagramToolsTest.java
@@ -2,8 +2,15 @@ package dev.omnidiagram.backend.mcp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import dev.omnidiagram.backend.AbstractIntegrationTest;
+import dev.omnidiagram.backend.conversion.ConversionException;
+import dev.omnidiagram.backend.conversion.DbmlConversionClient;
 import dev.omnidiagram.backend.diagram.Diagram;
 import dev.omnidiagram.backend.diagram.DiagramKind;
 import dev.omnidiagram.backend.diagram.DiagramService;
@@ -13,6 +20,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class DiagramToolsTest extends AbstractIntegrationTest {
 
@@ -24,6 +32,9 @@ class DiagramToolsTest extends AbstractIntegrationTest {
 
 	@Autowired
 	private ToolCallbackProvider toolCallbackProvider;
+
+	@MockitoBean
+	private DbmlConversionClient dbmlConversionClient;
 
 	@Test
 	void listDiagramsReturnsEveryDiagramWithItsId() {
@@ -126,6 +137,77 @@ class DiagramToolsTest extends AbstractIntegrationTest {
 				.isInstanceOf(IllegalArgumentException.class);
 		assertThatThrownBy(() -> diagramTools.exportDiagram(genericDiagram.getId(), "dbml"))
 				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void createDiagramWithFormatSqlPostgresStoresDbmlNotTheSubmittedSql() {
+		when(dbmlConversionClient.sqlToDbml("CREATE TABLE orders (id INT);", "postgres"))
+			.thenReturn("Table orders { id integer }");
+
+		DiagramTools.DiagramToolResult result = diagramTools.createDiagram(DiagramKind.SchemaDiagram, "Orders",
+				"CREATE TABLE orders (id INT);", "sql-postgres");
+
+		assertThat(result.content()).isEqualTo("Table orders { id integer }");
+		verify(dbmlConversionClient).sqlToDbml("CREATE TABLE orders (id INT);", "postgres");
+	}
+
+	@Test
+	void aFailedConversionDuringCreateDiagramCreatesNoDiagram() {
+		long countBefore = diagramTools.listDiagrams().size();
+		when(dbmlConversionClient.sqlToDbml(anyString(), anyString()))
+			.thenThrow(new ConversionException("Parse error at line 1: bad SQL"));
+
+		assertThatThrownBy(() -> diagramTools.createDiagram(DiagramKind.SchemaDiagram, "Orders", "not sql",
+				"sql-postgres")).isInstanceOf(ConversionException.class);
+
+		assertThat(diagramTools.listDiagrams()).hasSize((int) countBefore);
+	}
+
+	@Test
+	void aFailedConversionDuringUpdateDiagramLeavesExistingContentUntouchedAndAppendsNoRevision() {
+		Diagram diagram = diagramService.create(DiagramKind.SchemaDiagram, "Orders schema",
+				"Table orders { id integer }");
+		when(dbmlConversionClient.sqlToDbml(anyString(), anyString()))
+			.thenThrow(new ConversionException("Parse error at line 1: bad SQL"));
+
+		assertThatThrownBy(
+				() -> diagramTools.updateDiagram(diagram.getId(), null, "not sql", "sql-postgres"))
+			.isInstanceOf(ConversionException.class);
+
+		Diagram reloaded = diagramService.getById(diagram.getId());
+		assertThat(reloaded.getContent()).isEqualTo("Table orders { id integer }");
+		assertThat(diagramService.listRevisions(diagram.getId())).isEmpty();
+	}
+
+	@Test
+	void exportDiagramSqlPostgresReturnsConvertedSql() {
+		Diagram diagram = diagramService.create(DiagramKind.SchemaDiagram, "Orders schema",
+				"Table orders { id integer }");
+		when(dbmlConversionClient.dbmlToSql("Table orders { id integer }", "postgres"))
+			.thenReturn("CREATE TABLE orders (id INT);");
+
+		String exported = diagramTools.exportDiagram(diagram.getId(), "sql-postgres");
+
+		assertThat(exported).isEqualTo("CREATE TABLE orders (id INT);");
+	}
+
+	@Test
+	void exportDiagramDbmlMakesNoCallToTheConversionService() {
+		Diagram diagram = diagramService.create(DiagramKind.SchemaDiagram, "Orders schema",
+				"Table orders { id integer }");
+
+		diagramTools.exportDiagram(diagram.getId(), "dbml");
+
+		verifyNoInteractions(dbmlConversionClient);
+	}
+
+	@Test
+	void formatIsStillIgnoredForGenericDiagram() {
+		DiagramTools.DiagramToolResult result = diagramTools.createDiagram(DiagramKind.GenericDiagram, "Flow",
+				"flowchart TD", "sql-postgres");
+
+		assertThat(result.content()).isEqualTo("flowchart TD");
+		verify(dbmlConversionClient, never()).sqlToDbml(anyString(), anyString());
 	}
 
 	@Test

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -22,7 +22,7 @@ Returns: `{ id, title, kind, content, updatedAt }`
 
 - `kind`: `"SchemaDiagram" | "GenericDiagram"`
 - `content`: text
-- `format`: required when `kind = SchemaDiagram` — `"dbml" | "sql"`. SQL input is converted to DBML before storage (DBML is always the stored form) via the conversion service in the Next.js app — see [ADR-0009](./adr/0009-dbml-sql-conversion-lives-in-nextjs.md). Ignored for `GenericDiagram` (always Mermaid).
+- `format`: required when `kind = SchemaDiagram` — `"dbml" | "sql-postgres" | "sql-mysql" | "sql-sqlserver"`. SQL input is converted to DBML before storage (DBML is always the stored form) via the conversion service in the Next.js app — see [ADR-0009](./adr/0009-dbml-sql-conversion-lives-in-nextjs.md). The dialect-qualified `sql-*` names (matching `export_diagram`'s) exist because the conversion service needs to know which SQL dialect it's parsing; a plain `"sql"` format was underspecified for that. Ignored for `GenericDiagram` (always Mermaid).
 
 Returns the created Diagram (same shape as `get_diagram`).
 


### PR DESCRIPTION
## Summary
- Closes #12.
- New `backend/src/main/java/dev/omnidiagram/backend/conversion/DbmlConversionClient.java` — a `RestClient` wrapper with `sqlToDbml`/`dbmlToSql`, calling the `/api/internal/dbml/*` routes added in #11 at `omnidiagram.frontend-url` (`application.yml`: `${FRONTEND_INTERNAL_URL:http://localhost:3000}`, already set to `http://frontend:3000` in `docker-compose.yml`).
- New `ConversionException` (unchecked, matches the existing `DiagramNotFoundException` style) — a 4xx response becomes a `ConversionException` carrying the `{ error }` message from the response body; a connection failure/timeout becomes one naming the unreachable frontend URL rather than a raw `ResourceAccessException`.
- New `ConversionClientConfig` supplies the `RestClient.Builder` with a 5s connect/read timeout. `DbmlConversionClient` itself never touches the request factory — that's what let the test bind a `MockRestServiceServer` to a plain builder without the client clobbering the mock's request factory.
- `DiagramTools.create_diagram`/`update_diagram`/`export_diagram` now call the client instead of rejecting SQL formats as "not yet implemented". The conversion call happens before `diagramService.create`/`diagramService.update` in both paths (already true of the pre-existing structure), so a failed conversion creates no Diagram and appends no Revision.

## Deviation from the issue spec: `format` needed a dialect
`create_diagram`/`update_diagram` were documented with `format: "dbml" | "sql"` — no dialect. But the SQL parser needs to know postgres/mysql/mssql to parse correctly, and there was no way to express that. I confirmed with the user rather than silently defaulting to one dialect (e.g. always assuming postgres): extended `format` to `sql-postgres`/`sql-mysql`/`sql-sqlserver`, symmetric with `export_diagram`'s existing dialect-qualified names. `docs/mcp-tools.md` is updated. This is on top of #11's already-confirmed drop of `sql-sqlite` (upstream `@dbml/core` doesn't support it in any published version).

## Test plan
- [x] `./mvnw -B verify` (via `docker run maven:3.9-eclipse-temurin-21`) — 78/78 tests passing, `BUILD SUCCESS`, including:
  - `DbmlConversionClientTest` (6 tests, `MockRestServiceServer`, no real frontend): posts to the right path/body for `sqlToDbml` and for `dbmlToSql` on all three dialects; a 400 becomes a `ConversionException` carrying the returned message; a connection failure becomes a `ConversionException` naming the unreachable frontend URL
  - `DiagramToolsTest` additions (`@MockitoBean DbmlConversionClient`, still no real frontend): `create_diagram(format: "sql-postgres")` stores DBML not the submitted SQL; a failed conversion during `create_diagram` creates no Diagram (count unchanged); a failed conversion during `update_diagram` leaves existing content untouched and appends no Revision; `export_diagram(id, "sql-postgres")` returns converted SQL; `export_diagram(id, "dbml")` makes zero calls to the conversion client; `format` is still ignored (and the client untouched) for `GenericDiagram`
- [ ] The issue's end-to-end check ("call `create_diagram` with `format: 'sql'` through MCP with the full stack up and confirm `get_diagram` returns DBML") was **not** run live — it requires bringing up the full docker-compose stack (Postgres + backend + frontend + Caddy), and every code path it would exercise is already covered by the `MockRestServiceServer`/`@MockitoBean` tests above at the boundaries that actually change behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w