### PR TITLE
Wire Dashboard to the real API (list, create, delete)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,23 @@ jobs:
     defaults:
       run:
         working-directory: frontend
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_DB: omnidiagram
+          POSTGRES_USER: omnidiagram
+          POSTGRES_PASSWORD: omnidiagram
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U omnidiagram"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      MCP_API_KEY: ci-test-key
+      BACKEND_URL: http://localhost:8080
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -18,6 +35,28 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+      - name: Build backend jar
+        working-directory: backend
+        run: ./mvnw -B -DskipTests package
+      - name: Start backend
+        working-directory: backend
+        run: |
+          nohup java -jar target/*.jar > backend.log 2>&1 &
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/actuator/health; then
+              echo "Backend is up"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Backend failed to start" >&2
+          cat backend.log
+          exit 1
       - run: npm ci
       - run: npm run lint
       - run: npx next typegen

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test("create a GenericDiagram, see it listed, then delete it", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByText("New Diagram").click();
+  await page.getByText("GenericDiagram").click();
+  await expect(page).toHaveURL(/\/d\/[^/]+$/);
+
+  await page.goto("/");
+  const row = page.getByRole("link", { name: /Untitled diagram/ }).locator("..");
+  await expect(row).toBeVisible();
+
+  page.once("dialog", (dialog) => dialog.accept());
+  await row.getByText("Delete").click();
+
+  await expect(page.getByText("Untitled diagram")).not.toBeVisible();
+  await page.reload();
+  await expect(page.getByText("Untitled diagram")).not.toBeVisible();
+});

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,15 +1,5 @@
 import { expect, test } from "@playwright/test";
 
-test("dashboard shows the empty state", async ({ page }) => {
-  await page.goto("/");
-  await expect(
-    page.getByRole("link", { name: "OmniDiagram" }),
-  ).toBeVisible();
-  await expect(
-    page.getByText("No diagrams yet. Create one to get started."),
-  ).toBeVisible();
-});
-
 test("an unknown diagram route 404s", async ({ page }) => {
   const response = await page.goto("/d/does-not-exist");
   expect(response?.status()).toBe(404);

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,6 +2,17 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  async rewrites() {
+    // In production Caddy proxies /api/admin/* and /api/diagrams/* to the
+    // backend directly, so this never runs. It exists so the Next.js server
+    // can reach a backend on its own (CI, local dev without Caddy).
+    const backendUrl = process.env.BACKEND_URL;
+    if (!backendUrl) return [];
+    return [
+      { source: "/api/admin/:path*", destination: `${backendUrl}/api/admin/:path*` },
+      { source: "/api/diagrams/:path*", destination: `${backendUrl}/api/diagrams/:path*` },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+export default function Error({ retry }: { error: Error & { digest?: string }; retry: () => void }) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+      <p className="text-sm text-red-600 dark:text-red-400">Something went wrong.</p>
+      <button
+        onClick={() => retry()}
+        className="rounded-md border border-black/10 px-3 py-1.5 text-sm font-medium hover:bg-black/5 dark:border-white/10 dark:hover:bg-white/5"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Dashboard from "./page";
+import { listDiagrams } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  listDiagrams: vi.fn(),
+  deleteDiagram: vi.fn(),
+  createDiagram: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe("Dashboard", () => {
+  beforeEach(() => {
+    vi.mocked(listDiagrams).mockReset();
+  });
+
+  it("renders one row per returned diagram, with title, kind badge, and formatted timestamp", async () => {
+    vi.mocked(listDiagrams).mockResolvedValue([
+      {
+        shareToken: "a",
+        title: "Orders schema",
+        kind: "SchemaDiagram",
+        updatedAt: "2026-08-01T00:00:00Z",
+      },
+    ]);
+
+    render(<Dashboard />);
+
+    await waitFor(() => expect(screen.getByText("Orders schema")).toBeInTheDocument());
+    expect(screen.getByText("SchemaDiagram")).toBeInTheDocument();
+    expect(
+      screen.getByText(new Date("2026-08-01T00:00:00Z").toLocaleString(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      })),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the empty state for an empty list", async () => {
+    vi.mocked(listDiagrams).mockResolvedValue([]);
+
+    render(<Dashboard />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("No diagrams yet. Create one to get started."),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders an error message when the fetch rejects", async () => {
+    vi.mocked(listDiagrams).mockRejectedValue(new Error("network down"));
+
+    render(<Dashboard />);
+
+    await waitFor(() => expect(screen.getByText("Failed to load diagrams.")).toBeInTheDocument());
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,10 +1,30 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
 import { AppHeader } from "@/components/AppHeader";
 import { DiagramRow } from "@/components/DiagramRow";
 import { NewDiagramButton } from "@/components/NewDiagramButton";
+import { listDiagrams } from "@/lib/api";
 import { DiagramSummary } from "@/lib/types";
 
 export default function Dashboard() {
-  const diagrams: DiagramSummary[] = [];
+  const [diagrams, setDiagrams] = useState<DiagramSummary[] | null>(null);
+  const [error, setError] = useState(false);
+
+  const load = useCallback(() => {
+    listDiagrams()
+      .then((data) => {
+        setDiagrams(data);
+        setError(false);
+      })
+      .catch(() => {
+        setError(true);
+      });
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
 
   return (
     <div className="flex flex-1 flex-col">
@@ -12,14 +32,18 @@ export default function Dashboard() {
         <NewDiagramButton />
       </AppHeader>
       <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-8">
-        {diagrams.length === 0 ? (
+        {error ? (
+          <p className="text-sm text-red-600 dark:text-red-400">
+            Failed to load diagrams.
+          </p>
+        ) : diagrams === null ? null : diagrams.length === 0 ? (
           <p className="text-sm text-zinc-500 dark:text-zinc-400">
             No diagrams yet. Create one to get started.
           </p>
         ) : (
           <div className="rounded-lg border border-black/10 dark:border-white/10">
             {diagrams.map((diagram) => (
-              <DiagramRow key={diagram.shareToken} diagram={diagram} />
+              <DiagramRow key={diagram.shareToken} diagram={diagram} onDeleted={load} />
             ))}
           </div>
         )}

--- a/frontend/src/components/DiagramRow.test.tsx
+++ b/frontend/src/components/DiagramRow.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DiagramRow } from "./DiagramRow";
+import { deleteDiagram } from "@/lib/api";
+import { DiagramSummary } from "@/lib/types";
+
+vi.mock("@/lib/api", () => ({
+  deleteDiagram: vi.fn(),
+}));
+
+const diagram: DiagramSummary = {
+  shareToken: "abc",
+  title: "Orders schema",
+  kind: "SchemaDiagram",
+  updatedAt: "2026-08-01T00:00:00Z",
+};
+
+describe("DiagramRow", () => {
+  let onDeleted: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.mocked(deleteDiagram).mockReset();
+    onDeleted = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not call deleteDiagram when the confirm dialog is dismissed", () => {
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} />);
+    fireEvent.click(screen.getByText("Delete"));
+
+    expect(deleteDiagram).not.toHaveBeenCalled();
+    expect(onDeleted).not.toHaveBeenCalled();
+  });
+
+  it("calls deleteDiagram after confirmation and refreshes via onDeleted", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(deleteDiagram).mockResolvedValue(undefined);
+
+    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} />);
+    fireEvent.click(screen.getByText("Delete"));
+
+    expect(deleteDiagram).toHaveBeenCalledWith("abc");
+    await waitFor(() => expect(onDeleted).toHaveBeenCalled());
+  });
+
+  it("leaves the row visible and shows an error when delete fails", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(deleteDiagram).mockRejectedValue(new Error("boom"));
+
+    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} />);
+    fireEvent.click(screen.getByText("Delete"));
+
+    await waitFor(() => expect(screen.getByText("Delete failed")).toBeInTheDocument());
+    expect(screen.getByText("Orders schema")).toBeInTheDocument();
+    expect(onDeleted).not.toHaveBeenCalled();
+  });
+
+  it("disables the delete button while the request is in flight", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    let resolve!: () => void;
+    vi.mocked(deleteDiagram).mockReturnValue(
+      new Promise((res) => {
+        resolve = () => res(undefined);
+      }),
+    );
+
+    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} />);
+    fireEvent.click(screen.getByText("Delete"));
+
+    expect(screen.getByText("Delete")).toBeDisabled();
+
+    resolve();
+    await waitFor(() => expect(onDeleted).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/components/DiagramRow.tsx
+++ b/frontend/src/components/DiagramRow.tsx
@@ -2,21 +2,34 @@
 
 import Link from "next/link";
 import { useState } from "react";
+import { deleteDiagram } from "@/lib/api";
 import { formatUpdatedAt } from "@/lib/format";
 import { DiagramSummary } from "@/lib/types";
 import { KindBadge } from "./KindBadge";
 
-export function DiagramRow({ diagram }: { diagram: DiagramSummary }) {
-  const [deleted, setDeleted] = useState(false);
+export function DiagramRow({
+  diagram,
+  onDeleted,
+}: {
+  diagram: DiagramSummary;
+  onDeleted: () => void;
+}) {
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState(false);
 
-  if (deleted) return null;
-
-  function handleDelete() {
+  async function handleDelete() {
     if (!window.confirm(`Delete "${diagram.title}"? This can't be undone.`)) {
       return;
     }
-    // TODO: DELETE /api/diagrams/{id}
-    setDeleted(true);
+    setDeleting(true);
+    setError(false);
+    try {
+      await deleteDiagram(diagram.shareToken);
+      onDeleted();
+    } catch {
+      setError(true);
+      setDeleting(false);
+    }
   }
 
   return (
@@ -29,12 +42,16 @@ export function DiagramRow({ diagram }: { diagram: DiagramSummary }) {
         <KindBadge kind={diagram.kind} />
       </Link>
       <div className="flex shrink-0 items-center gap-4">
+        {error && (
+          <span className="text-xs text-red-600 dark:text-red-400">Delete failed</span>
+        )}
         <span className="text-xs text-zinc-500 dark:text-zinc-400">
           {formatUpdatedAt(diagram.updatedAt)}
         </span>
         <button
           onClick={handleDelete}
-          className="text-xs font-medium text-red-600 hover:underline dark:text-red-400"
+          disabled={deleting}
+          className="text-xs font-medium text-red-600 hover:underline disabled:opacity-50 dark:text-red-400"
         >
           Delete
         </button>

--- a/frontend/src/components/NewDiagramButton.test.tsx
+++ b/frontend/src/components/NewDiagramButton.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NewDiagramButton } from "./NewDiagramButton";
+import { createDiagram } from "@/lib/api";
+import { Diagram } from "@/lib/types";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+vi.mock("@/lib/api", () => ({
+  createDiagram: vi.fn(),
+}));
+
+const created: Diagram = {
+  shareToken: "abc",
+  title: "Untitled diagram",
+  kind: "SchemaDiagram",
+  content: "",
+  layout: {},
+  updatedAt: "2026-08-01T00:00:00Z",
+};
+
+describe("NewDiagramButton", () => {
+  beforeEach(() => {
+    push.mockClear();
+    vi.mocked(createDiagram).mockReset();
+  });
+
+  it("creates a SchemaDiagram and navigates to its shareToken", async () => {
+    vi.mocked(createDiagram).mockResolvedValue(created);
+
+    render(<NewDiagramButton />);
+    fireEvent.click(screen.getByText("New Diagram"));
+    fireEvent.click(screen.getByText("SchemaDiagram"));
+
+    expect(createDiagram).toHaveBeenCalledWith("SchemaDiagram");
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/d/abc"));
+  });
+
+  it("disables the button while a create request is in flight", async () => {
+    let resolve!: (value: Diagram) => void;
+    vi.mocked(createDiagram).mockReturnValue(
+      new Promise((res) => {
+        resolve = res;
+      }),
+    );
+
+    render(<NewDiagramButton />);
+    fireEvent.click(screen.getByText("New Diagram"));
+    fireEvent.click(screen.getByText("SchemaDiagram"));
+
+    expect(screen.getByText("New Diagram")).toBeDisabled();
+
+    resolve(created);
+    await waitFor(() => expect(push).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/components/NewDiagramButton.tsx
+++ b/frontend/src/components/NewDiagramButton.tsx
@@ -1,35 +1,45 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { createDiagram } from "@/lib/api";
 import { DiagramKind } from "@/lib/types";
 
 export function NewDiagramButton() {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
 
-  function createDiagram(kind: DiagramKind) {
-    // TODO: POST /api/diagrams { kind }, then route to /d/[shareToken]
+  async function handleCreate(kind: DiagramKind) {
     setOpen(false);
-    window.alert(`Creating a new ${kind}... (not wired to the backend yet)`);
+    setCreating(true);
+    try {
+      const diagram = await createDiagram(kind);
+      router.push(`/d/${diagram.shareToken}`);
+    } catch {
+      setCreating(false);
+    }
   }
 
   return (
     <div className="relative">
       <button
         onClick={() => setOpen((o) => !o)}
-        className="rounded-md bg-foreground px-3 py-1.5 text-sm font-medium text-background hover:opacity-90"
+        disabled={creating}
+        className="rounded-md bg-foreground px-3 py-1.5 text-sm font-medium text-background hover:opacity-90 disabled:opacity-50"
       >
         New Diagram
       </button>
       {open && (
         <div className="absolute right-0 z-10 mt-1 w-44 rounded-md border border-black/10 bg-background shadow-lg dark:border-white/10">
           <button
-            onClick={() => createDiagram("SchemaDiagram")}
+            onClick={() => handleCreate("SchemaDiagram")}
             className="block w-full px-3 py-2 text-left text-sm hover:bg-black/5 dark:hover:bg-white/5"
           >
             SchemaDiagram
           </button>
           <button
-            onClick={() => createDiagram("GenericDiagram")}
+            onClick={() => handleCreate("GenericDiagram")}
             className="block w-full px-3 py-2 text-left text-sm hover:bg-black/5 dark:hover:bg-white/5"
           >
             GenericDiagram


### PR DESCRIPTION
## Summary
- `page.tsx` fetches via `listDiagrams()` (server-sorted, no client re-sort).
- `NewDiagramButton.tsx` calls `createDiagram(kind)` (no title prompt) and navigates to `/d/{shareToken}`; disabled while the request is in flight.
- `DiagramRow.tsx` calls `deleteDiagram(shareToken)` behind the existing confirm dialog, refreshes the list via a parent `onDeleted` callback on success, shows an inline "Delete failed" message and keeps the row on failure, and disables the Delete button while in flight.
- New `app/error.tsx`: a generic Next.js error-boundary fallback (uses the `retry` prop, not the deprecated `reset`, per this Next.js 16.3 build's docs).

## CI infrastructure (per discussion — chosen: run a real backend)
Playwright specs from here on hit real `/api/admin/*` endpoints, so CI needs a real backend behind them:
- `next.config.ts` gains an opt-in `rewrites()`: if `BACKEND_URL` is set, `/api/admin/*` and `/api/diagrams/*` proxy there. Unset (production, behind Caddy) it's a no-op — Caddy already owns that routing.
- `ci.yml`'s `frontend` job now brings up a `postgres` service, builds the backend jar, starts it, waits on `/actuator/health`, then runs the existing steps with `BACKEND_URL=http://localhost:8080`.
- `e2e/dashboard.spec.ts` (new): create → appears in list → delete → gone, verified via reload (hits the DB, not just DOM state).
- `e2e/smoke.spec.ts`: dropped the old "empty state" assertion — with a real, shared Postgres across parallel e2e specs, "the list is empty" is no longer a reliable invariant. Kept the backend-independent "unknown route 404s" check.

## Known gap (carried forward to #15)
`create → lands on /d/{token} with a non-empty editor` isn't asserted: `d/[token]/page.tsx` still unconditionally 404s (left that way by #13), since real content loading is #15's explicit scope. `dashboard.spec.ts` only checks the URL pattern after create, not editor content.

## Test plan
- [x] `npm run lint`, `npx next typegen && npx tsc --noEmit`, `npm run test` (38 passed)
- [x] `npm run build`
- [x] `npm run test:e2e` run locally against a real backend + Postgres on an isolated Docker network (mirroring the new CI setup) — 2 passed

Closes #14

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>