### PR TITLE
Load and save diagrams with Save button and unsaved-changes indicator

### DIFF
--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -3,18 +3,20 @@ import { expect, test } from "@playwright/test";
 test("create a GenericDiagram, see it listed, then delete it", async ({ page }) => {
   await page.goto("/");
 
-  await page.getByText("New Diagram").click();
-  await page.getByText("GenericDiagram").click();
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "GenericDiagram" }).click();
   await expect(page).toHaveURL(/\/d\/[^/]+$/);
+  const token = page.url().split("/d/")[1];
 
   await page.goto("/");
-  const row = page.getByRole("link", { name: /Untitled diagram/ }).locator("..");
+  const rowLink = page.locator(`a[href="/d/${token}"]`);
+  const row = rowLink.locator("..");
   await expect(row).toBeVisible();
 
   page.once("dialog", (dialog) => dialog.accept());
   await row.getByText("Delete").click();
 
-  await expect(page.getByText("Untitled diagram")).not.toBeVisible();
+  await expect(rowLink).not.toBeVisible();
   await page.reload();
-  await expect(page.getByText("Untitled diagram")).not.toBeVisible();
+  await expect(page.locator(`a[href="/d/${token}"]`)).not.toBeVisible();
 });

--- a/frontend/e2e/editor.spec.ts
+++ b/frontend/e2e/editor.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+
+test("edit, save, and reload preserves the change", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "SchemaDiagram" }).click();
+  await expect(page).toHaveURL(/\/d\/[^/]+$/);
+
+  const textarea = page.locator("textarea");
+  const edited = "Table orders {\n  id integer [primary key]\n}\n";
+  await textarea.fill(edited);
+  await expect(page.getByText("Unsaved changes")).toBeVisible();
+
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(page.getByText("Saved")).toBeVisible();
+
+  await page.reload();
+  await expect(page.locator("textarea")).toHaveValue(edited);
+});
+
+test("navigating away with unsaved changes warns first", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "SchemaDiagram" }).click();
+  await expect(page).toHaveURL(/\/d\/[^/]+$/);
+
+  await page.locator("textarea").fill("Table orders {\n  id integer [primary key]\n}\n");
+  await expect(page.getByText("Unsaved changes")).toBeVisible();
+
+  let dialogMessage = "";
+  page.once("dialog", (dialog) => {
+    dialogMessage = dialog.message();
+    dialog.dismiss();
+  });
+  await page.getByRole("link", { name: "OmniDiagram" }).click();
+
+  expect(dialogMessage).toContain("unsaved changes");
+  await expect(page).toHaveURL(/\/d\/[^/]+$/);
+});

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test("an unknown diagram route 404s", async ({ page }) => {
-  const response = await page.goto("/d/does-not-exist");
-  expect(response?.status()).toBe(404);
+test("an unknown diagram route shows the not-found page", async ({ page }) => {
+  await page.goto("/d/does-not-exist");
+  await expect(page.getByText("Diagram not found")).toBeVisible();
 });

--- a/frontend/src/app/d/[token]/not-found.tsx
+++ b/frontend/src/app/d/[token]/not-found.tsx
@@ -1,0 +1,10 @@
+export default function DiagramNotFound() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-2 p-8 text-center">
+      <p className="text-sm font-medium">Diagram not found</p>
+      <p className="text-sm text-zinc-500 dark:text-zinc-400">
+        It may have been deleted, or the link is incorrect.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/app/d/[token]/page.tsx
+++ b/frontend/src/app/d/[token]/page.tsx
@@ -1,10 +1,73 @@
-import { notFound } from "next/navigation";
+"use client";
 
-export default async function DiagramEditorPage({
+import { notFound } from "next/navigation";
+import { use, useEffect, useState } from "react";
+import { EditorHeader } from "@/components/EditorHeader";
+import { SchemaDiagramEditor } from "@/components/SchemaDiagramEditor";
+import { GenericDiagramEditor } from "@/components/GenericDiagramEditor";
+import { useDiagramEditor } from "@/hooks/useDiagramEditor";
+import { ApiError, getDiagram } from "@/lib/api";
+import { Diagram } from "@/lib/types";
+
+function Editor({ diagram }: { diagram: Diagram }) {
+  const editor = useDiagramEditor(diagram);
+
+  return (
+    <div className="flex flex-1 flex-col">
+      <EditorHeader
+        diagram={editor.diagram}
+        isDirty={editor.isDirty}
+        isSaving={editor.isSaving}
+        error={editor.error}
+        onSave={editor.save}
+      />
+      {editor.diagram.kind === "SchemaDiagram" ? (
+        <SchemaDiagramEditor content={editor.content} onContentChange={editor.setContent} />
+      ) : (
+        <GenericDiagramEditor content={editor.content} onContentChange={editor.setContent} />
+      )}
+    </div>
+  );
+}
+
+export default function DiagramEditorPage({
   params,
 }: {
   params: Promise<{ token: string }>;
 }) {
-  await params;
-  notFound();
+  const { token } = use(params);
+  const [diagram, setDiagram] = useState<Diagram | null>(null);
+  const [missing, setMissing] = useState(false);
+  const [loadError, setLoadError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getDiagram(token)
+      .then((data) => {
+        if (!cancelled) setDiagram(data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (err instanceof ApiError && (err.status === 404 || err.status === 400)) {
+          setMissing(true);
+        } else {
+          setLoadError(err instanceof Error ? err : new Error("Failed to load diagram"));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  if (missing) {
+    notFound();
+  }
+  if (loadError) {
+    throw loadError;
+  }
+  if (!diagram) {
+    return null;
+  }
+
+  return <Editor diagram={diagram} />;
 }

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -1,10 +1,20 @@
 import Link from "next/link";
 import { ReactNode } from "react";
 
-export function AppHeader({ children }: { children?: ReactNode }) {
+export function AppHeader({
+  children,
+  onNavigateAway,
+}: {
+  children?: ReactNode;
+  onNavigateAway?: (event: { preventDefault: () => void }) => void;
+}) {
   return (
     <header className="flex h-14 shrink-0 items-center justify-between border-b border-black/10 px-4 dark:border-white/10">
-      <Link href="/" className="text-sm font-semibold tracking-tight">
+      <Link
+        href="/"
+        onNavigate={onNavigateAway}
+        className="text-sm font-semibold tracking-tight"
+      >
         OmniDiagram
       </Link>
       <div className="flex items-center gap-2">{children}</div>

--- a/frontend/src/components/EditorHeader.test.tsx
+++ b/frontend/src/components/EditorHeader.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EditorHeader } from "./EditorHeader";
+import { Diagram } from "@/lib/types";
+
+const diagram: Diagram = {
+  shareToken: "abc",
+  title: "Orders",
+  kind: "SchemaDiagram",
+  content: "Table orders {}",
+  layout: {},
+  updatedAt: "2026-08-01T00:00:00Z",
+};
+
+describe("EditorHeader", () => {
+  it("disables Save and shows Saved when clean", () => {
+    render(
+      <EditorHeader diagram={diagram} isDirty={false} isSaving={false} error={null} onSave={vi.fn()} />,
+    );
+    expect(screen.getByText("Save")).toBeDisabled();
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+  });
+
+  it("enables Save and shows Unsaved changes when dirty", () => {
+    render(
+      <EditorHeader diagram={diagram} isDirty={true} isSaving={false} error={null} onSave={vi.fn()} />,
+    );
+    expect(screen.getByText("Save")).not.toBeDisabled();
+    expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+  });
+
+  it("disables Save while a save is in flight", () => {
+    render(
+      <EditorHeader diagram={diagram} isDirty={true} isSaving={true} error={null} onSave={vi.fn()} />,
+    );
+    expect(screen.getByText("Save")).toBeDisabled();
+  });
+
+  it("shows the error message instead of the dirty indicator when present", () => {
+    render(
+      <EditorHeader
+        diagram={diagram}
+        isDirty={true}
+        isSaving={false}
+        error="Failed to save"
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Failed to save")).toBeInTheDocument();
+    expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/EditorHeader.tsx
+++ b/frontend/src/components/EditorHeader.tsx
@@ -1,12 +1,46 @@
+"use client";
+
 import { Diagram } from "@/lib/types";
 import { AppHeader } from "./AppHeader";
 import { KindBadge } from "./KindBadge";
 
-export function EditorHeader({ diagram }: { diagram: Diagram }) {
+export function EditorHeader({
+  diagram,
+  isDirty,
+  isSaving,
+  error,
+  onSave,
+}: {
+  diagram: Diagram;
+  isDirty: boolean;
+  isSaving: boolean;
+  error: string | null;
+  onSave: () => void;
+}) {
   return (
-    <AppHeader>
+    <AppHeader
+      onNavigateAway={(event) => {
+        if (isDirty && !window.confirm("You have unsaved changes. Leave anyway?")) {
+          event.preventDefault();
+        }
+      }}
+    >
       <span className="text-sm font-medium">{diagram.title}</span>
       <KindBadge kind={diagram.kind} />
+      {error ? (
+        <span className="text-xs text-red-600 dark:text-red-400">{error}</span>
+      ) : (
+        <span className="text-xs text-zinc-500 dark:text-zinc-400">
+          {isDirty ? "Unsaved changes" : "Saved"}
+        </span>
+      )}
+      <button
+        onClick={onSave}
+        disabled={!isDirty || isSaving}
+        className="rounded-md border border-black/10 px-3 py-1.5 text-sm font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:hover:bg-white/5"
+      >
+        Save
+      </button>
       <button className="rounded-md border border-black/10 px-3 py-1.5 text-sm font-medium hover:bg-black/5 dark:border-white/10 dark:hover:bg-white/5">
         Export
       </button>

--- a/frontend/src/components/GenericDiagramEditor.tsx
+++ b/frontend/src/components/GenericDiagramEditor.tsx
@@ -3,8 +3,13 @@
 import { useEffect, useId, useState } from "react";
 import mermaid from "mermaid";
 
-export function GenericDiagramEditor({ content }: { content: string }) {
-  const [source, setSource] = useState(content);
+export function GenericDiagramEditor({
+  content,
+  onContentChange,
+}: {
+  content: string;
+  onContentChange: (content: string) => void;
+}) {
   const [svg, setSvg] = useState("");
   const [error, setError] = useState<string | null>(null);
   const renderId = useId().replace(/:/g, "");
@@ -16,7 +21,7 @@ export function GenericDiagramEditor({ content }: { content: string }) {
   useEffect(() => {
     let cancelled = false;
     mermaid
-      .render(`mermaid-${renderId}`, source)
+      .render(`mermaid-${renderId}`, content)
       .then(({ svg }) => {
         if (!cancelled) {
           setSvg(svg);
@@ -31,13 +36,13 @@ export function GenericDiagramEditor({ content }: { content: string }) {
     return () => {
       cancelled = true;
     };
-  }, [source, renderId]);
+  }, [content, renderId]);
 
   return (
     <div className="grid flex-1 grid-cols-2">
       <textarea
-        value={source}
-        onChange={(e) => setSource(e.target.value)}
+        value={content}
+        onChange={(e) => onContentChange(e.target.value)}
         spellCheck={false}
         className="h-full resize-none border-r border-black/10 bg-transparent p-4 font-mono text-sm outline-none dark:border-white/10"
       />

--- a/frontend/src/components/SchemaDiagramEditor.tsx
+++ b/frontend/src/components/SchemaDiagramEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   Background,
   Controls,
@@ -48,15 +48,20 @@ function tablesToNodes(dbml: string): { nodes: Node[]; error: string | null } {
   }
 }
 
-export function SchemaDiagramEditor({ content }: { content: string }) {
-  const [dbml, setDbml] = useState(content);
-  const { nodes, error } = useMemo(() => tablesToNodes(dbml), [dbml]);
+export function SchemaDiagramEditor({
+  content,
+  onContentChange,
+}: {
+  content: string;
+  onContentChange: (content: string) => void;
+}) {
+  const { nodes, error } = useMemo(() => tablesToNodes(content), [content]);
 
   return (
     <div className="grid flex-1 grid-cols-2">
       <textarea
-        value={dbml}
-        onChange={(e) => setDbml(e.target.value)}
+        value={content}
+        onChange={(e) => onContentChange(e.target.value)}
         spellCheck={false}
         className="h-full resize-none border-r border-black/10 bg-transparent p-4 font-mono text-sm outline-none dark:border-white/10"
       />

--- a/frontend/src/hooks/useDiagramEditor.test.ts
+++ b/frontend/src/hooks/useDiagramEditor.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDiagramEditor } from "./useDiagramEditor";
+import { updateDiagram } from "@/lib/api";
+import { Diagram } from "@/lib/types";
+
+vi.mock("@/lib/api", () => ({
+  updateDiagram: vi.fn(),
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+const initial: Diagram = {
+  shareToken: "abc",
+  title: "Orders",
+  kind: "SchemaDiagram",
+  content: "Table orders {}",
+  layout: {},
+  updatedAt: "2026-08-01T00:00:00Z",
+};
+
+describe("useDiagramEditor", () => {
+  beforeEach(() => {
+    vi.mocked(updateDiagram).mockReset();
+  });
+
+  it("starts clean with Save effectively disabled (isDirty false)", () => {
+    const { result } = renderHook(() => useDiagramEditor(initial));
+    expect(result.current.isDirty).toBe(false);
+    expect(result.current.content).toBe(initial.content);
+  });
+
+  it("marks dirty when the content changes", () => {
+    const { result } = renderHook(() => useDiagramEditor(initial));
+    act(() => result.current.setContent("Table orders { id int }"));
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it("marks clean again when hand-reverted to the last-saved value", () => {
+    const { result } = renderHook(() => useDiagramEditor(initial));
+    act(() => result.current.setContent("changed"));
+    act(() => result.current.setContent(initial.content));
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it("clears the dirty state after a successful save", async () => {
+    vi.mocked(updateDiagram).mockResolvedValue({ ...initial, content: "new content" });
+    const { result } = renderHook(() => useDiagramEditor(initial));
+    act(() => result.current.setContent("new content"));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(result.current.isDirty).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("keeps the dirty state, keeps the content, and shows the error on a failed save", async () => {
+    vi.mocked(updateDiagram).mockRejectedValue(new Error("network down"));
+    const { result } = renderHook(() => useDiagramEditor(initial));
+    act(() => result.current.setContent("new content"));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(result.current.isDirty).toBe(true);
+    expect(result.current.content).toBe("new content");
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it("does not send a second save while one is already in flight", async () => {
+    let resolve!: (value: Diagram) => void;
+    vi.mocked(updateDiagram).mockReturnValue(
+      new Promise((res) => {
+        resolve = res;
+      }),
+    );
+    const { result } = renderHook(() => useDiagramEditor(initial));
+    act(() => result.current.setContent("new content"));
+
+    act(() => {
+      result.current.save();
+      result.current.save();
+    });
+
+    expect(updateDiagram).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolve({ ...initial, content: "new content" });
+    });
+  });
+
+  it("sends only the changed fields", async () => {
+    vi.mocked(updateDiagram).mockResolvedValue({ ...initial, content: "new content" });
+    const { result } = renderHook(() => useDiagramEditor(initial));
+    act(() => result.current.setContent("new content"));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(updateDiagram).toHaveBeenCalledWith("abc", { content: "new content" });
+  });
+});

--- a/frontend/src/hooks/useDiagramEditor.ts
+++ b/frontend/src/hooks/useDiagramEditor.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ApiError, updateDiagram } from "@/lib/api";
+import { Diagram } from "@/lib/types";
+
+export function useDiagramEditor(initial: Diagram) {
+  const [diagram, setDiagram] = useState(initial);
+  const [content, setContent] = useState(initial.content);
+  const [lastSavedContent, setLastSavedContent] = useState(initial.content);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const savingRef = useRef(false);
+
+  const isDirty = content !== lastSavedContent;
+
+  const save = useCallback(async () => {
+    if (savingRef.current || content === lastSavedContent) {
+      return;
+    }
+    savingRef.current = true;
+    setIsSaving(true);
+    setError(null);
+    try {
+      const updated = await updateDiagram(diagram.shareToken, { content });
+      setLastSavedContent(updated.content);
+      setDiagram(updated);
+      setContent(updated.content);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Failed to save");
+    } finally {
+      savingRef.current = false;
+      setIsSaving(false);
+    }
+  }, [content, lastSavedContent, diagram.shareToken]);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key === "s") {
+        event.preventDefault();
+        save();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [save]);
+
+  useEffect(() => {
+    function handleBeforeUnload(event: BeforeUnloadEvent) {
+      if (isDirty) {
+        event.preventDefault();
+        event.returnValue = "";
+      }
+    }
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [isDirty]);
+
+  return { diagram, content, setContent, isDirty, isSaving, error, save };
+}


### PR DESCRIPTION
## Summary
- `d/[token]/page.tsx` loads via `getDiagram(token)` client-side (fetches must run in the browser per ADR-0008 — relative paths only resolve against the page's own origin) and renders `not-found.tsx` for a 404 or a malformed (non-UUID) token, instead of crashing.
- New `hooks/useDiagramEditor.ts`: owns `content`/`isDirty`/`isSaving`/`error`/`save()`. `isDirty` is derived by comparing the live buffer against the last-saved value (not a flag set on keystroke), so editing then hand-reverting goes clean again. `save()` sends only `{content}` — never a no-op patch. Cmd/Ctrl+S saves without opening the browser's save dialog; `beforeunload` warns on a dirty buffer.
- `EditorHeader.tsx` gained the Save button (disabled when clean or mid-save) and the dirty/"Saved"/error indicator.
- `AppHeader.tsx`'s home link now takes an optional `onNavigateAway` prop wired through `next/link`'s `onNavigate` (the documented Next 16 pattern for blocking in-app navigation), so leaving the editor with unsaved changes prompts first — not just on tab-close.
- `SchemaDiagramEditor`/`GenericDiagramEditor` no longer own their own content state; both are now controlled by the hook via `content`/`onContentChange`.

## Known soft-404 tradeoff
Since the existence check runs client-side (required — `api.ts` calls can't resolve relative paths from a Server Component without a base URL, which ADR-0008 deliberately avoids), the initial navigation to any token always returns HTTP 200; the not-found UI only appears post-hydration. This is the exact tradeoff Next's own docs describe for client-fetched existence checks. `e2e/smoke.spec.ts` was adjusted to assert on the rendered not-found content rather than the response status code.

A malformed (non-UUID) token gets a 400 from Spring's `@PathVariable UUID` binding, not a 404 — treated as "not found" too, since that's indistinguishable from "unknown" to the user.

## Also fixed
Two latent e2e flakiness sources, surfaced by this PR's new specs running in parallel against a shared Postgres (introduced by #14's CI change):
- `dashboard.spec.ts` now matches its row by the created diagram's own `href` instead of by title text — multiple "Untitled diagram" rows can coexist across parallel spec files.
- Dropdown clicks target the button role instead of text, since `KindBadge` spans share text with the New Diagram dropdown's menu items.

## Test plan
- [x] `npm run lint`, `npx next typegen && npx tsc --noEmit`, `npm run test` (49 passed, incl. new `useDiagramEditor.test.ts` and `EditorHeader.test.tsx`)
- [x] `npm run build`
- [x] `npm run test:e2e` run locally against a real backend + Postgres (4 passed): dashboard create/list/delete, editor edit→save→reload persists, edit→navigate-away warns, unknown-token not-found

Closes #15

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>