### PR TITLE
Persist SchemaDiagram table positions

### DIFF
--- a/frontend/e2e/layout.spec.ts
+++ b/frontend/e2e/layout.spec.ts
@@ -1,0 +1,65 @@
+import { expect, Locator, Page, test } from "@playwright/test";
+
+async function dragNode(page: Page, node: Locator, dx: number, dy: number) {
+  const box = await node.boundingBox();
+  if (!box) throw new Error("node has no bounding box");
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width / 2 + dx, box.y + box.height / 2 + dy, { steps: 10 });
+  await page.mouse.up();
+}
+
+test("drag a table, save, reload, and the position persists", async ({ page, request }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "SchemaDiagram" }).click();
+  await expect(page).toHaveURL(/\/d\/[^/]+$/);
+  const token = page.url().split("/d/")[1];
+
+  const node = page.locator(".react-flow__node").first();
+  await expect(node).toBeVisible();
+
+  await dragNode(page, node, 150, 150);
+  await expect(page.getByText("Unsaved changes")).toBeVisible();
+
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(page.getByText("Saved")).toBeVisible();
+
+  // A pixel-position comparison across a reload is brittle: react-flow's
+  // fitView re-centers/re-zooms the viewport on each mount, so on-screen
+  // coordinates aren't comparable even when the underlying model position
+  // is identical. Read the persisted value back from the server instead.
+  const response = await request.get(`/api/diagrams/${token}`);
+  const body = await response.json();
+  const saved = body.layout.table_name;
+  expect(saved).toBeDefined();
+  expect(Number.isFinite(saved.x)).toBe(true);
+  expect(Number.isFinite(saved.y)).toBe(true);
+  expect(saved).not.toEqual({ x: 0, y: 0 });
+
+  await page.reload();
+  await expect(page.locator(".react-flow__node").first()).toBeVisible();
+});
+
+test("adding a table to the DBML keeps existing tables' positions", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "SchemaDiagram" }).click();
+  await expect(page).toHaveURL(/\/d\/[^/]+$/);
+
+  const node = page.locator(".react-flow__node").first();
+  await expect(node).toBeVisible();
+  await dragNode(page, node, 150, 100);
+  const draggedBox = await node.boundingBox();
+
+  const textarea = page.locator("textarea");
+  const existing = await textarea.inputValue();
+  await textarea.fill(`${existing}\nTable extra {\n  id integer [primary key]\n}\n`);
+
+  const originalNode = page.locator(".react-flow__node", { hasText: "table_name" });
+  await expect(originalNode).toBeVisible();
+  const boxAfterEdit = await originalNode.boundingBox();
+
+  expect(Math.abs((boxAfterEdit?.x ?? 0) - (draggedBox?.x ?? 0))).toBeLessThan(5);
+  expect(Math.abs((boxAfterEdit?.y ?? 0) - (draggedBox?.y ?? 0))).toBeLessThan(5);
+});

--- a/frontend/src/app/d/[token]/page.tsx
+++ b/frontend/src/app/d/[token]/page.tsx
@@ -22,7 +22,12 @@ function Editor({ diagram }: { diagram: Diagram }) {
         onSave={editor.save}
       />
       {editor.diagram.kind === "SchemaDiagram" ? (
-        <SchemaDiagramEditor content={editor.content} onContentChange={editor.setContent} />
+        <SchemaDiagramEditor
+          content={editor.content}
+          onContentChange={editor.setContent}
+          layout={editor.layout}
+          onLayoutChange={editor.setLayout}
+        />
       ) : (
         <GenericDiagramEditor content={editor.content} onContentChange={editor.setContent} />
       )}

--- a/frontend/src/components/SchemaDiagramEditor.tsx
+++ b/frontend/src/components/SchemaDiagramEditor.tsx
@@ -2,22 +2,31 @@
 
 import { useMemo } from "react";
 import {
+  applyNodeChanges,
   Background,
   Controls,
   Node,
+  NodeChange,
   ReactFlow,
   ReactFlowProvider,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { Parser } from "@dbml/core";
+import { mergeLayout } from "@/lib/layout";
+import { Position } from "@/lib/types";
 
-function tablesToNodes(dbml: string): { nodes: Node[]; error: string | null } {
+function tablesToNodes(
+  dbml: string,
+  layout: Record<string, Position>,
+): { nodes: Node[]; error: string | null; tableNames: string[] } {
   try {
     const database = new Parser().parse(dbml, "dbml");
     const tables = database.schemas[0]?.tables ?? [];
-    const nodes: Node[] = tables.map((table, index) => ({
+    const tableNames = tables.map((table) => table.name);
+    const positions = mergeLayout(tableNames, layout);
+    const nodes: Node[] = tables.map((table) => ({
       id: table.name,
-      position: { x: (index % 4) * 260, y: Math.floor(index / 4) * 220 },
+      position: positions[table.name],
       data: {
         label: (
           <div className="text-left">
@@ -42,20 +51,41 @@ function tablesToNodes(dbml: string): { nodes: Node[]; error: string | null } {
         width: 220,
       },
     }));
-    return { nodes, error: null };
+    return { nodes, error: null, tableNames };
   } catch (err) {
-    return { nodes: [], error: err instanceof Error ? err.message : "Invalid DBML" };
+    return { nodes: [], error: err instanceof Error ? err.message : "Invalid DBML", tableNames: [] };
   }
 }
 
 export function SchemaDiagramEditor({
   content,
   onContentChange,
+  layout,
+  onLayoutChange,
 }: {
   content: string;
   onContentChange: (content: string) => void;
+  layout: Record<string, Position>;
+  onLayoutChange: (layout: Record<string, Position>) => void;
 }) {
-  const { nodes, error } = useMemo(() => tablesToNodes(content), [content]);
+  const { nodes, error, tableNames } = useMemo(
+    () => tablesToNodes(content, layout),
+    [content, layout],
+  );
+
+  function handleNodesChange(changes: NodeChange[]) {
+    if (!changes.some((change) => change.type === "position")) {
+      return;
+    }
+    const updatedNodes = applyNodeChanges(changes, nodes);
+    const nextLayout: Record<string, Position> = {};
+    for (const node of updatedNodes) {
+      if (tableNames.includes(node.id)) {
+        nextLayout[node.id] = { x: node.position.x, y: node.position.y };
+      }
+    }
+    onLayoutChange(nextLayout);
+  }
 
   return (
     <div className="grid flex-1 grid-cols-2">
@@ -70,7 +100,7 @@ export function SchemaDiagramEditor({
           <div className="p-4 text-sm text-red-600 dark:text-red-400">{error}</div>
         ) : (
           <ReactFlowProvider>
-            <ReactFlow nodes={nodes} edges={[]} fitView>
+            <ReactFlow nodes={nodes} edges={[]} onNodesChange={handleNodesChange} fitView>
               <Background />
               <Controls />
             </ReactFlow>

--- a/frontend/src/hooks/useDiagramEditor.test.ts
+++ b/frontend/src/hooks/useDiagramEditor.test.ts
@@ -108,4 +108,24 @@ describe("useDiagramEditor", () => {
 
     expect(updateDiagram).toHaveBeenCalledWith("abc", { content: "new content" });
   });
+
+  it("marks dirty when the layout changes", () => {
+    const { result } = renderHook(() => useDiagramEditor(initial));
+    act(() => result.current.setLayout({ orders: { x: 10, y: 20 } }));
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it("sends only the layout when only the layout changed", async () => {
+    const newLayout = { orders: { x: 10, y: 20 } };
+    vi.mocked(updateDiagram).mockResolvedValue({ ...initial, layout: newLayout });
+    const { result } = renderHook(() => useDiagramEditor(initial));
+    act(() => result.current.setLayout(newLayout));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(updateDiagram).toHaveBeenCalledWith("abc", { layout: newLayout });
+    expect(result.current.isDirty).toBe(false);
+  });
 });

--- a/frontend/src/hooks/useDiagramEditor.ts
+++ b/frontend/src/hooks/useDiagramEditor.ts
@@ -2,37 +2,47 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiError, updateDiagram } from "@/lib/api";
-import { Diagram } from "@/lib/types";
+import { layoutsEqual } from "@/lib/layout";
+import { Diagram, DiagramPatch } from "@/lib/types";
 
 export function useDiagramEditor(initial: Diagram) {
   const [diagram, setDiagram] = useState(initial);
   const [content, setContent] = useState(initial.content);
+  const [layout, setLayout] = useState(initial.layout);
   const [lastSavedContent, setLastSavedContent] = useState(initial.content);
+  const [lastSavedLayout, setLastSavedLayout] = useState(initial.layout);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const savingRef = useRef(false);
 
-  const isDirty = content !== lastSavedContent;
+  const contentDirty = content !== lastSavedContent;
+  const layoutDirty = !layoutsEqual(layout, lastSavedLayout);
+  const isDirty = contentDirty || layoutDirty;
 
   const save = useCallback(async () => {
-    if (savingRef.current || content === lastSavedContent) {
+    if (savingRef.current || (!contentDirty && !layoutDirty)) {
       return;
     }
     savingRef.current = true;
     setIsSaving(true);
     setError(null);
     try {
-      const updated = await updateDiagram(diagram.shareToken, { content });
+      const patch: DiagramPatch = {};
+      if (contentDirty) patch.content = content;
+      if (layoutDirty) patch.layout = layout;
+      const updated = await updateDiagram(diagram.shareToken, patch);
       setLastSavedContent(updated.content);
+      setLastSavedLayout(updated.layout);
       setDiagram(updated);
       setContent(updated.content);
+      setLayout(updated.layout);
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "Failed to save");
     } finally {
       savingRef.current = false;
       setIsSaving(false);
     }
-  }, [content, lastSavedContent, diagram.shareToken]);
+  }, [content, contentDirty, layout, layoutDirty, diagram.shareToken]);
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -56,5 +66,15 @@ export function useDiagramEditor(initial: Diagram) {
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
   }, [isDirty]);
 
-  return { diagram, content, setContent, isDirty, isSaving, error, save };
+  return {
+    diagram,
+    content,
+    setContent,
+    layout,
+    setLayout,
+    isDirty,
+    isSaving,
+    error,
+    save,
+  };
 }

--- a/frontend/src/lib/layout.test.ts
+++ b/frontend/src/lib/layout.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { layoutsEqual, mergeLayout } from "./layout";
+import { Position } from "./types";
+
+describe("mergeLayout", () => {
+  it("applies stored positions to matching tables", () => {
+    const merged = mergeLayout(["orders"], { orders: { x: 100, y: 50 } });
+    expect(merged.orders).toEqual({ x: 100, y: 50 });
+  });
+
+  it("gives a table absent from layout a grid position, and two such tables do not overlap", () => {
+    const merged = mergeLayout(["orders", "customers"], {});
+    expect(merged.orders).not.toEqual(merged.customers);
+  });
+
+  it("drops a layout key with no matching table", () => {
+    const merged = mergeLayout(["orders"], { orders: { x: 1, y: 2 }, ghost: { x: 9, y: 9 } });
+    expect(merged).not.toHaveProperty("ghost");
+    expect(Object.keys(merged)).toEqual(["orders"]);
+  });
+
+  it("produces the same grid as current behavior for an empty layout", () => {
+    const merged = mergeLayout(["a", "b", "c", "d", "e"], {});
+    expect(merged.a).toEqual({ x: 0, y: 0 });
+    expect(merged.b).toEqual({ x: 260, y: 0 });
+    expect(merged.c).toEqual({ x: 520, y: 0 });
+    expect(merged.d).toEqual({ x: 780, y: 0 });
+    expect(merged.e).toEqual({ x: 0, y: 220 });
+  });
+
+  it("falls back to a grid position for a malformed entry instead of producing NaN", () => {
+    const merged = mergeLayout(["orders"], {
+      orders: { x: "oops", y: 1 } as unknown as Position,
+    });
+    expect(Number.isFinite(merged.orders.x)).toBe(true);
+    expect(Number.isFinite(merged.orders.y)).toBe(true);
+  });
+
+  it("falls back to a grid position when x or y is missing", () => {
+    const merged = mergeLayout(["orders"], { orders: { y: 1 } as unknown as Position });
+    expect(Number.isFinite(merged.orders.x)).toBe(true);
+    expect(Number.isFinite(merged.orders.y)).toBe(true);
+  });
+});
+
+describe("layoutsEqual", () => {
+  it("is true for two empty layouts", () => {
+    expect(layoutsEqual({}, {})).toBe(true);
+  });
+
+  it("is true for layouts with the same keys and positions", () => {
+    expect(layoutsEqual({ a: { x: 1, y: 2 } }, { a: { x: 1, y: 2 } })).toBe(true);
+  });
+
+  it("is false when a position differs", () => {
+    expect(layoutsEqual({ a: { x: 1, y: 2 } }, { a: { x: 1, y: 3 } })).toBe(false);
+  });
+
+  it("is false when the key sets differ", () => {
+    expect(layoutsEqual({ a: { x: 1, y: 2 } }, { b: { x: 1, y: 2 } })).toBe(false);
+  });
+});

--- a/frontend/src/lib/layout.ts
+++ b/frontend/src/lib/layout.ts
@@ -1,0 +1,44 @@
+import { Position } from "./types";
+
+const GRID_COLS = 4;
+const COL_WIDTH = 260;
+const ROW_HEIGHT = 220;
+
+function gridPosition(index: number): Position {
+  return { x: (index % GRID_COLS) * COL_WIDTH, y: Math.floor(index / GRID_COLS) * ROW_HEIGHT };
+}
+
+function isValidPosition(value: unknown): value is Position {
+  if (typeof value !== "object" || value === null) return false;
+  const { x, y } = value as Position;
+  return Number.isFinite(x) && Number.isFinite(y);
+}
+
+export function mergeLayout(
+  tableNames: string[],
+  layout: Record<string, Position>,
+): Record<string, Position> {
+  const merged: Record<string, Position> = {};
+  let autoIndex = 0;
+  for (const name of tableNames) {
+    const stored = layout[name];
+    if (isValidPosition(stored)) {
+      merged[name] = stored;
+    } else {
+      merged[name] = gridPosition(autoIndex);
+      autoIndex += 1;
+    }
+  }
+  return merged;
+}
+
+export function layoutsEqual(a: Record<string, Position>, b: Record<string, Position>): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => {
+    const pa = a[key];
+    const pb = b[key];
+    return pb !== undefined && pa.x === pb.x && pa.y === pb.y;
+  });
+}


### PR DESCRIPTION
## Summary
- New `frontend/src/lib/layout.ts` (pure): `mergeLayout(tableNames, layout)` keys positions by table name, tolerating drift between stored layout and current DBML per ADR-0011 — a table missing from layout gets an auto-placed grid slot (indexed independently so auto-placed tables never collide with each other), a layout entry with no matching table is dropped, and a malformed entry (missing/non-finite x or y) falls back to a grid slot rather than letting `NaN` reach react-flow. Also `layoutsEqual` for the hook's dirty check.
- `SchemaDiagramEditor.tsx` seeds node positions via `mergeLayout` instead of always recomputing a fixed grid, and reports drags back up through a new `onLayoutChange` prop (via react-flow's `onNodesChange` + `applyNodeChanges`, filtered to position changes only).
- `useDiagramEditor.ts` now tracks `layout` alongside `content`: `isDirty` is true if either differs from its last-saved value, and `save()` sends only whichever of `{content, layout}` actually changed.
- `d/[token]/page.tsx` wires `editor.layout`/`editor.setLayout` into `SchemaDiagramEditor`.

## Test plan
- [x] `npm run lint`, `npx next typegen && npx tsc --noEmit`, `npm run test` (61 passed, incl. new `layout.test.ts` covering all 5 drift scenarios from the issue, plus 2 new `useDiagramEditor` tests for layout dirty-tracking)
- [x] `npm run build`
- [x] `npm run test:e2e` run locally against a real backend + Postgres (6 passed, all specs): drag → save → reload persists (verified via a GET against the API, not on-screen pixel comparison — react-flow's `fitView` re-centers/re-zooms per mount, so screen coordinates for an identical model position aren't comparable across two separate page loads; this follows the issue's own note that exact-pixel e2e assertions are brittle), and editing DBML to add a table keeps the existing table's dragged position.

Closes #16

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>