### PR TITLE
Add Revision history panel with revert

### DIFF
--- a/frontend/e2e/revisions.spec.ts
+++ b/frontend/e2e/revisions.spec.ts
@@ -1,0 +1,100 @@
+import { expect, Locator, Page, test } from "@playwright/test";
+
+async function dragNode(page: Page, node: Locator, dx: number, dy: number) {
+  const box = await node.boundingBox();
+  if (!box) throw new Error("node has no bounding box");
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width / 2 + dx, box.y + box.height / 2 + dy, { steps: 10 });
+  await page.mouse.up();
+}
+
+test("revert restores content and layout together and appends rather than rewinds history", async ({
+  page,
+  request,
+}) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "SchemaDiagram" }).click();
+  await expect(page).toHaveURL(/\/d\/[^/]+$/);
+  const token = page.url().split("/d/")[1];
+
+  const textarea = page.locator("textarea");
+  const node = page.locator(".react-flow__node").first();
+  await expect(node).toBeVisible();
+
+  // First save: drag the table to P1, then change the content.
+  await dragNode(page, node, 120, 80);
+  const contentA = "Table table_name {\n  id integer [primary key]\n}\n";
+  await textarea.fill(contentA);
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(page.getByText("Saved")).toBeVisible();
+
+  const afterFirstSave = await (await request.get(`/api/diagrams/${token}`)).json();
+  const layoutAtA = afterFirstSave.layout.table_name;
+  expect(layoutAtA).toBeDefined();
+
+  // Second save: drag the table further to P2, then change the content again.
+  await dragNode(page, page.locator(".react-flow__node").first(), 80, 60);
+  const contentB = "Table table_name {\n  id integer [primary key]\n  name varchar\n}\n";
+  await textarea.fill(contentB);
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(page.getByText("Saved")).toBeVisible();
+
+  // Open History: two entries so far (the state right before each save).
+  await page.getByRole("button", { name: "History" }).click();
+  const restoreButtons = page.getByRole("button", { name: "Restore" });
+  await expect(restoreButtons).toHaveCount(2);
+
+  // Revert to the newest entry: content A with layout P1.
+  page.once("dialog", (dialog) => dialog.accept());
+  await restoreButtons.first().click();
+
+  await expect(textarea).toHaveValue(contentA);
+  // Revert is a forward write: one more entry, not fewer.
+  await expect(restoreButtons).toHaveCount(3);
+
+  const afterRevert = await (await request.get(`/api/diagrams/${token}`)).json();
+  expect(afterRevert.content).toBe(contentA);
+  expect(afterRevert.layout.table_name).toEqual(layoutAtA);
+
+  await page.reload();
+  await expect(page.locator("textarea")).toHaveValue(contentA);
+});
+
+test("history panel shows empty state before any save", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "SchemaDiagram" }).click();
+  await expect(page).toHaveURL(/\/d\/[^/]+$/);
+
+  await page.getByRole("button", { name: "History" }).click();
+  await expect(page.getByText("No previous versions yet")).toBeVisible();
+});
+
+test("reverting with unsaved changes warns before discarding them", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "SchemaDiagram" }).click();
+  await expect(page).toHaveURL(/\/d\/[^/]+$/);
+
+  const textarea = page.locator("textarea");
+  await textarea.fill("Table table_name {\n  id integer [primary key]\n  note varchar\n}\n");
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(page.getByText("Saved")).toBeVisible();
+
+  await textarea.fill("Table table_name {\n  id integer [primary key]\n  extra varchar\n}\n");
+  await expect(page.getByText("Unsaved changes")).toBeVisible();
+
+  await page.getByRole("button", { name: "History" }).click();
+
+  let dialogMessage = "";
+  page.once("dialog", (dialog) => {
+    dialogMessage = dialog.message();
+    dialog.dismiss();
+  });
+  await page.getByRole("button", { name: "Restore" }).first().click();
+
+  expect(dialogMessage.toLowerCase()).toContain("unsaved changes");
+  await expect(page.getByText("Unsaved changes")).toBeVisible();
+});

--- a/frontend/src/app/d/[token]/page.tsx
+++ b/frontend/src/app/d/[token]/page.tsx
@@ -3,6 +3,7 @@
 import { notFound } from "next/navigation";
 import { use, useEffect, useState } from "react";
 import { EditorHeader } from "@/components/EditorHeader";
+import { RevisionPanel } from "@/components/RevisionPanel";
 import { SchemaDiagramEditor } from "@/components/SchemaDiagramEditor";
 import { GenericDiagramEditor } from "@/components/GenericDiagramEditor";
 import { useDiagramEditor } from "@/hooks/useDiagramEditor";
@@ -11,6 +12,7 @@ import { Diagram } from "@/lib/types";
 
 function Editor({ diagram }: { diagram: Diagram }) {
   const editor = useDiagramEditor(diagram);
+  const [historyOpen, setHistoryOpen] = useState(false);
 
   return (
     <div className="flex flex-1 flex-col">
@@ -20,17 +22,32 @@ function Editor({ diagram }: { diagram: Diagram }) {
         isSaving={editor.isSaving}
         error={editor.error}
         onSave={editor.save}
+        isHistoryOpen={historyOpen}
+        onToggleHistory={() => setHistoryOpen((open) => !open)}
       />
-      {editor.diagram.kind === "SchemaDiagram" ? (
-        <SchemaDiagramEditor
-          content={editor.content}
-          onContentChange={editor.setContent}
-          layout={editor.layout}
-          onLayoutChange={editor.setLayout}
-        />
-      ) : (
-        <GenericDiagramEditor content={editor.content} onContentChange={editor.setContent} />
-      )}
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex flex-1 flex-col">
+          {editor.diagram.kind === "SchemaDiagram" ? (
+            <SchemaDiagramEditor
+              content={editor.content}
+              onContentChange={editor.setContent}
+              layout={editor.layout}
+              onLayoutChange={editor.setLayout}
+            />
+          ) : (
+            <GenericDiagramEditor content={editor.content} onContentChange={editor.setContent} />
+          )}
+        </div>
+        {historyOpen && (
+          <RevisionPanel
+            shareToken={editor.diagram.shareToken}
+            isDirty={editor.isDirty}
+            refreshToken={editor.diagram.updatedAt}
+            onClose={() => setHistoryOpen(false)}
+            onReverted={editor.applyDiagram}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/EditorHeader.test.tsx
+++ b/frontend/src/components/EditorHeader.test.tsx
@@ -15,7 +15,15 @@ const diagram: Diagram = {
 describe("EditorHeader", () => {
   it("disables Save and shows Saved when clean", () => {
     render(
-      <EditorHeader diagram={diagram} isDirty={false} isSaving={false} error={null} onSave={vi.fn()} />,
+      <EditorHeader
+        diagram={diagram}
+        isDirty={false}
+        isSaving={false}
+        error={null}
+        onSave={vi.fn()}
+        isHistoryOpen={false}
+        onToggleHistory={vi.fn()}
+      />,
     );
     expect(screen.getByText("Save")).toBeDisabled();
     expect(screen.getByText("Saved")).toBeInTheDocument();
@@ -23,7 +31,15 @@ describe("EditorHeader", () => {
 
   it("enables Save and shows Unsaved changes when dirty", () => {
     render(
-      <EditorHeader diagram={diagram} isDirty={true} isSaving={false} error={null} onSave={vi.fn()} />,
+      <EditorHeader
+        diagram={diagram}
+        isDirty={true}
+        isSaving={false}
+        error={null}
+        onSave={vi.fn()}
+        isHistoryOpen={false}
+        onToggleHistory={vi.fn()}
+      />,
     );
     expect(screen.getByText("Save")).not.toBeDisabled();
     expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
@@ -31,7 +47,15 @@ describe("EditorHeader", () => {
 
   it("disables Save while a save is in flight", () => {
     render(
-      <EditorHeader diagram={diagram} isDirty={true} isSaving={true} error={null} onSave={vi.fn()} />,
+      <EditorHeader
+        diagram={diagram}
+        isDirty={true}
+        isSaving={true}
+        error={null}
+        onSave={vi.fn()}
+        isHistoryOpen={false}
+        onToggleHistory={vi.fn()}
+      />,
     );
     expect(screen.getByText("Save")).toBeDisabled();
   });
@@ -44,9 +68,28 @@ describe("EditorHeader", () => {
         isSaving={false}
         error="Failed to save"
         onSave={vi.fn()}
+        isHistoryOpen={false}
+        onToggleHistory={vi.fn()}
       />,
     );
     expect(screen.getByText("Failed to save")).toBeInTheDocument();
     expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
+  });
+
+  it("calls onToggleHistory when the History button is clicked", () => {
+    const onToggleHistory = vi.fn();
+    render(
+      <EditorHeader
+        diagram={diagram}
+        isDirty={false}
+        isSaving={false}
+        error={null}
+        onSave={vi.fn()}
+        isHistoryOpen={false}
+        onToggleHistory={onToggleHistory}
+      />,
+    );
+    screen.getByText("History").click();
+    expect(onToggleHistory).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/EditorHeader.tsx
+++ b/frontend/src/components/EditorHeader.tsx
@@ -10,12 +10,16 @@ export function EditorHeader({
   isSaving,
   error,
   onSave,
+  isHistoryOpen,
+  onToggleHistory,
 }: {
   diagram: Diagram;
   isDirty: boolean;
   isSaving: boolean;
   error: string | null;
   onSave: () => void;
+  isHistoryOpen: boolean;
+  onToggleHistory: () => void;
 }) {
   return (
     <AppHeader
@@ -40,6 +44,13 @@ export function EditorHeader({
         className="rounded-md border border-black/10 px-3 py-1.5 text-sm font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:hover:bg-white/5"
       >
         Save
+      </button>
+      <button
+        onClick={onToggleHistory}
+        aria-pressed={isHistoryOpen}
+        className="rounded-md border border-black/10 px-3 py-1.5 text-sm font-medium hover:bg-black/5 dark:border-white/10 dark:hover:bg-white/5"
+      >
+        History
       </button>
       <button className="rounded-md border border-black/10 px-3 py-1.5 text-sm font-medium hover:bg-black/5 dark:border-white/10 dark:hover:bg-white/5">
         Export

--- a/frontend/src/components/RevisionPanel.test.tsx
+++ b/frontend/src/components/RevisionPanel.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RevisionPanel } from "./RevisionPanel";
+import { listRevisions, revertToRevision } from "@/lib/api";
+import { Diagram, RevisionSummary } from "@/lib/types";
+
+vi.mock("@/lib/api", () => ({
+  listRevisions: vi.fn(),
+  revertToRevision: vi.fn(),
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+const revisions: RevisionSummary[] = [
+  { id: "r2", createdAt: "2026-08-02T00:00:00Z", contentPreview: "Table orders { id int }" },
+  { id: "r1", createdAt: "2026-08-01T00:00:00Z", contentPreview: "Table orders {}" },
+];
+
+const restoredDiagram: Diagram = {
+  shareToken: "abc",
+  title: "Orders",
+  kind: "SchemaDiagram",
+  content: "Table orders {}",
+  layout: {},
+  updatedAt: "2026-08-03T00:00:00Z",
+};
+
+function renderPanel(overrides: Partial<Parameters<typeof RevisionPanel>[0]> = {}) {
+  const onClose = vi.fn();
+  const onReverted = vi.fn();
+  const utils = render(
+    <RevisionPanel
+      shareToken="abc"
+      isDirty={false}
+      refreshToken="v1"
+      onClose={onClose}
+      onReverted={onReverted}
+      {...overrides}
+    />,
+  );
+  return { ...utils, onClose, onReverted };
+}
+
+describe("RevisionPanel", () => {
+  beforeEach(() => {
+    vi.mocked(listRevisions).mockReset();
+    vi.mocked(revertToRevision).mockReset();
+    vi.spyOn(window, "confirm").mockReset();
+  });
+
+  it("renders entries newest-first with timestamps and previews", async () => {
+    vi.mocked(listRevisions).mockResolvedValue(revisions);
+    renderPanel();
+
+    await waitFor(() => expect(screen.getAllByText("Restore")).toHaveLength(2));
+    const previews = screen.getAllByText(/Table orders/);
+    expect(previews[0]).toHaveTextContent("Table orders { id int }");
+    expect(previews[1]).toHaveTextContent("Table orders {}");
+  });
+
+  it("renders the empty state for an empty history", async () => {
+    vi.mocked(listRevisions).mockResolvedValue([]);
+    renderPanel();
+
+    expect(await screen.findByText("No previous versions yet")).toBeInTheDocument();
+  });
+
+  it("clicking revert asks for confirmation and calls revertToRevision only on confirm", async () => {
+    vi.mocked(listRevisions).mockResolvedValue(revisions);
+    vi.mocked(revertToRevision).mockResolvedValue(restoredDiagram);
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    renderPanel();
+
+    const restoreButtons = await screen.findAllByText("Restore");
+    fireEvent.click(restoreButtons[0]);
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(revertToRevision).not.toHaveBeenCalled();
+  });
+
+  it("a successful revert refreshes the list and updates the editor content", async () => {
+    vi.mocked(listRevisions)
+      .mockResolvedValueOnce(revisions)
+      .mockResolvedValueOnce([
+        { id: "r3", createdAt: "2026-08-03T00:00:00Z", contentPreview: "Table orders { id int }" },
+        ...revisions,
+      ]);
+    vi.mocked(revertToRevision).mockResolvedValue(restoredDiagram);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const { onReverted } = renderPanel();
+
+    const restoreButtons = await screen.findAllByText("Restore");
+    fireEvent.click(restoreButtons[1]);
+
+    await waitFor(() => expect(onReverted).toHaveBeenCalledWith(restoredDiagram));
+    expect(revertToRevision).toHaveBeenCalledWith("abc", "r1");
+    await waitFor(() => expect(listRevisions).toHaveBeenCalledTimes(2));
+  });
+
+  it("a failed revert shows an error and leaves the content untouched", async () => {
+    vi.mocked(listRevisions).mockResolvedValue(revisions);
+    vi.mocked(revertToRevision).mockRejectedValue(new Error("boom"));
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const { onReverted } = renderPanel();
+
+    const restoreButtons = await screen.findAllByText("Restore");
+    fireEvent.click(restoreButtons[0]);
+
+    expect(await screen.findByText("Failed to restore that version")).toBeInTheDocument();
+    expect(onReverted).not.toHaveBeenCalled();
+  });
+
+  it("reloads the list when refreshToken changes, as happens after a save", async () => {
+    vi.mocked(listRevisions).mockResolvedValue(revisions);
+    const { rerender } = renderPanel({ refreshToken: "v1" });
+
+    await waitFor(() => expect(listRevisions).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <RevisionPanel
+        shareToken="abc"
+        isDirty={false}
+        refreshToken="v2"
+        onClose={vi.fn()}
+        onReverted={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(listRevisions).toHaveBeenCalledTimes(2));
+  });
+});

--- a/frontend/src/components/RevisionPanel.tsx
+++ b/frontend/src/components/RevisionPanel.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { ApiError, listRevisions, revertToRevision } from "@/lib/api";
+import { formatUpdatedAt } from "@/lib/format";
+import { Diagram, RevisionSummary } from "@/lib/types";
+
+export function RevisionPanel({
+  shareToken,
+  isDirty,
+  refreshToken,
+  onClose,
+  onReverted,
+}: {
+  shareToken: string;
+  isDirty: boolean;
+  refreshToken: string;
+  onClose: () => void;
+  onReverted: (diagram: Diagram) => void;
+}) {
+  const [revisions, setRevisions] = useState<RevisionSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [revertingId, setRevertingId] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    listRevisions(shareToken)
+      .then((data) => {
+        setRevisions(data);
+        setError(null);
+      })
+      .catch(() => {
+        setError("Failed to load revision history");
+      });
+  }, [shareToken]);
+
+  useEffect(() => {
+    load();
+  }, [load, refreshToken]);
+
+  async function handleRevert(revision: RevisionSummary) {
+    const timestamp = formatUpdatedAt(revision.createdAt);
+    const message = isDirty
+      ? `Restore the version from ${timestamp}? Your unsaved changes will be lost.`
+      : `Restore the version from ${timestamp}?`;
+    if (!window.confirm(message)) {
+      return;
+    }
+
+    setRevertingId(revision.id);
+    setError(null);
+    try {
+      const restored = await revertToRevision(shareToken, revision.id);
+      onReverted(restored);
+      load();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Failed to restore that version");
+    } finally {
+      setRevertingId(null);
+    }
+  }
+
+  return (
+    <aside className="flex w-80 shrink-0 flex-col border-l border-black/10 dark:border-white/10">
+      <div className="flex h-12 shrink-0 items-center justify-between border-b border-black/10 px-4 dark:border-white/10">
+        <span className="text-sm font-medium">History</span>
+        <button
+          onClick={onClose}
+          className="text-xs text-zinc-500 hover:underline dark:text-zinc-400"
+        >
+          Close
+        </button>
+      </div>
+      <div className="flex-1 overflow-auto">
+        {error && (
+          <p className="px-4 py-3 text-xs text-red-600 dark:text-red-400">{error}</p>
+        )}
+        {revisions === null ? (
+          <p className="px-4 py-3 text-xs text-zinc-500 dark:text-zinc-400">Loading…</p>
+        ) : revisions.length === 0 ? (
+          <p className="px-4 py-3 text-xs text-zinc-500 dark:text-zinc-400">
+            No previous versions yet
+          </p>
+        ) : (
+          <ul>
+            {revisions.map((revision) => (
+              <li
+                key={revision.id}
+                className="border-b border-black/5 px-4 py-3 last:border-0 dark:border-white/5"
+              >
+                <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                  {formatUpdatedAt(revision.createdAt)}
+                </p>
+                <p className="mt-1 truncate text-sm">{revision.contentPreview}</p>
+                <button
+                  onClick={() => handleRevert(revision)}
+                  disabled={revertingId === revision.id}
+                  className="mt-2 text-xs font-medium text-blue-600 hover:underline disabled:opacity-50 dark:text-blue-400"
+                >
+                  Restore
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/hooks/useDiagramEditor.test.ts
+++ b/frontend/src/hooks/useDiagramEditor.test.ts
@@ -128,4 +128,16 @@ describe("useDiagramEditor", () => {
     expect(updateDiagram).toHaveBeenCalledWith("abc", { layout: newLayout });
     expect(result.current.isDirty).toBe(false);
   });
+
+  it("applyDiagram replaces content and layout and clears dirty state", () => {
+    const { result } = renderHook(() => useDiagramEditor(initial));
+    act(() => result.current.setContent("changed"));
+
+    const restored: Diagram = { ...initial, content: "restored content", layout: { orders: { x: 1, y: 2 } } };
+    act(() => result.current.applyDiagram(restored));
+
+    expect(result.current.content).toBe("restored content");
+    expect(result.current.layout).toEqual({ orders: { x: 1, y: 2 } });
+    expect(result.current.isDirty).toBe(false);
+  });
 });

--- a/frontend/src/hooks/useDiagramEditor.ts
+++ b/frontend/src/hooks/useDiagramEditor.ts
@@ -19,6 +19,14 @@ export function useDiagramEditor(initial: Diagram) {
   const layoutDirty = !layoutsEqual(layout, lastSavedLayout);
   const isDirty = contentDirty || layoutDirty;
 
+  const applyDiagram = useCallback((updated: Diagram) => {
+    setLastSavedContent(updated.content);
+    setLastSavedLayout(updated.layout);
+    setDiagram(updated);
+    setContent(updated.content);
+    setLayout(updated.layout);
+  }, []);
+
   const save = useCallback(async () => {
     if (savingRef.current || (!contentDirty && !layoutDirty)) {
       return;
@@ -31,18 +39,14 @@ export function useDiagramEditor(initial: Diagram) {
       if (contentDirty) patch.content = content;
       if (layoutDirty) patch.layout = layout;
       const updated = await updateDiagram(diagram.shareToken, patch);
-      setLastSavedContent(updated.content);
-      setLastSavedLayout(updated.layout);
-      setDiagram(updated);
-      setContent(updated.content);
-      setLayout(updated.layout);
+      applyDiagram(updated);
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "Failed to save");
     } finally {
       savingRef.current = false;
       setIsSaving(false);
     }
-  }, [content, contentDirty, layout, layoutDirty, diagram.shareToken]);
+  }, [content, contentDirty, layout, layoutDirty, diagram.shareToken, applyDiagram]);
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -76,5 +80,6 @@ export function useDiagramEditor(initial: Diagram) {
     isSaving,
     error,
     save,
+    applyDiagram,
   };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Diagram, DiagramKind, DiagramPatch, DiagramSummary } from "./types";
+import { Diagram, DiagramKind, DiagramPatch, DiagramSummary, RevisionSummary } from "./types";
 
 export class ApiError extends Error {
   readonly status: number;
@@ -58,5 +58,15 @@ export function updateDiagram(shareToken: string, patch: DiagramPatch): Promise<
   return request(`/api/diagrams/${shareToken}`, {
     method: "PUT",
     body: JSON.stringify(patch),
+  });
+}
+
+export function listRevisions(shareToken: string): Promise<RevisionSummary[]> {
+  return request(`/api/diagrams/${shareToken}/revisions`);
+}
+
+export function revertToRevision(shareToken: string, revisionId: string): Promise<Diagram> {
+  return request(`/api/diagrams/${shareToken}/revisions/${revisionId}/revert`, {
+    method: "POST",
   });
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -22,3 +22,9 @@ export interface DiagramPatch {
   content?: string;
   layout?: Record<string, Position>;
 }
+
+export interface RevisionSummary {
+  id: string;
+  createdAt: string;
+  contentPreview: string;
+}


### PR DESCRIPTION
## Summary
- New `RevisionPanel` side panel toggled by a "History" button in `EditorHeader`, listing revisions newest-first with timestamp + content preview
- `frontend/src/lib/api.ts` gains `listRevisions`/`revertToRevision`; `useDiagramEditor` gains `applyDiagram` (shared by `save` and revert) to update content/layout/diagram state and clear dirty status
- Revert asks for confirmation naming the timestamp, and warns explicitly when there are unsaved changes about to be lost
- Revert is a forward write per ADR-0006/issue #9: the panel refetches afterward and shows one more entry, never fewer

Closes #17

## Test plan
- [x] `npx eslint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` (vitest) — 69/69 passing, including new `RevisionPanel.test.tsx` and `useDiagramEditor.test.ts` coverage for `applyDiagram`
- [x] `npm run build` — succeeds
- [x] `npx playwright test` against a real backend + Postgres on an isolated Docker network — 9/9 passing, including new `e2e/revisions.spec.ts` (two saves → two entries, revert restores content+layout together, reload persists it, history grows to three entries, empty-history state, unsaved-changes warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w