### PR TITLE
Run Playwright e2e single-worker with a retry in CI

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -3,6 +3,12 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
+  // CI runs on a 2-vCPU GitHub-hosted runner; a full Chromium instance per
+  // worker plus the Next.js server was CPU-starving enough to intermittently
+  // time out an unrelated assertion (see issue #45). One worker removes the
+  // contention; the retry is a stopgap in case some contention remains.
+  workers: process.env.CI ? 1 : undefined,
+  retries: process.env.CI ? 1 : 0,
   reporter: "html",
   use: {
     baseURL: "http://localhost:3000",


### PR DESCRIPTION
## Summary
- `frontend/playwright.config.ts`: in CI only, run Playwright with `workers: 1` and `retries: 1` instead of `fullyParallel`'s default parallelism
- Root cause of #45: the GitHub-hosted runner is 2 vCPUs; two Chromium instances plus the `next start` server under load intermittently starved a single, different one of the 9 specs each run (~1 in 3), never a logic bug — confirmed by seeing it hit an untouched pre-existing test (`layout.spec.ts`) as often as a brand-new one
- Local runs are unaffected (`workers` stays default there), so local iteration speed is unchanged

Closes #45

## Test plan
- [x] Verified locally with `CI=true` against a real backend+Postgres (isolated Docker network): Playwright reports "Running 9 tests using 1 worker" and all 9 pass
- [x] `npx eslint`, `npx next typegen && npx tsc --noEmit` — clean
- [ ] CI itself is the real test here — will watch for a clean, non-flaky run on this PR before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w