### PR TITLE
Add export menu and SQL/DBML import

### DIFF
--- a/frontend/e2e/export.spec.ts
+++ b/frontend/e2e/export.spec.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+
+test("export DBML from a SchemaDiagram downloads a file containing the table", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "SchemaDiagram" }).click();
+  await expect(page).toHaveURL(/\/d\/[^/]+$/);
+
+  await page.getByRole("button", { name: "Export", exact: true }).click();
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    page.getByText("DBML", { exact: true }).click(),
+  ]);
+
+  expect(download.suggestedFilename()).toMatch(/\.dbml$/);
+  const path = await download.path();
+  const content = readFileSync(path!, "utf-8");
+  expect(content).toContain("table_name");
+});
+
+test("export SQL (PostgreSQL) downloads a file containing CREATE TABLE", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "SchemaDiagram" }).click();
+  await expect(page).toHaveURL(/\/d\/[^/]+$/);
+
+  await page.getByRole("button", { name: "Export", exact: true }).click();
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    page.getByText("SQL (PostgreSQL)").click(),
+  ]);
+
+  expect(download.suggestedFilename()).toMatch(/\.postgres\.sql$/);
+  const stream = await download.createReadStream();
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream!) {
+    chunks.push(chunk as Buffer);
+  }
+  const text = Buffer.concat(chunks).toString("utf-8");
+  expect(text.toUpperCase()).toContain("CREATE TABLE");
+});
+
+test("importing a .sql file replaces the buffer and marks it dirty", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "SchemaDiagram" }).click();
+  await expect(page).toHaveURL(/\/d\/[^/]+$/);
+
+  await page.getByRole("button", { name: "Import" }).click();
+  const dialog = page.getByRole("dialog", { name: "Import" });
+  await page.setInputFiles("input[type=file]", {
+    name: "customers.sql",
+    mimeType: "text/plain",
+    buffer: Buffer.from("CREATE TABLE customers (id INTEGER PRIMARY KEY, name VARCHAR(255));"),
+  });
+  await dialog.getByRole("button", { name: "Import" }).click();
+
+  await expect(page.locator("textarea").first()).toContainText("customers");
+  await expect(page.getByText("Unsaved changes")).toBeVisible();
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@dbml/core": "^10.1.0",
         "@xyflow/react": "^12.11.3",
+        "html-to-image": "^1.11.13",
         "mermaid": "^11.16.1",
         "next": "16.3.1",
         "react": "19.2.8",
@@ -6618,6 +6619,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@dbml/core": "^10.1.0",
     "@xyflow/react": "^12.11.3",
+    "html-to-image": "^1.11.13",
     "mermaid": "^11.16.1",
     "next": "16.3.1",
     "react": "19.2.8",

--- a/frontend/src/app/d/[token]/page.tsx
+++ b/frontend/src/app/d/[token]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { notFound } from "next/navigation";
-import { use, useEffect, useState } from "react";
+import { use, useEffect, useRef, useState } from "react";
 import { EditorHeader } from "@/components/EditorHeader";
 import { RevisionPanel } from "@/components/RevisionPanel";
 import { SchemaDiagramEditor } from "@/components/SchemaDiagramEditor";
@@ -13,20 +13,24 @@ import { Diagram } from "@/lib/types";
 function Editor({ diagram }: { diagram: Diagram }) {
   const editor = useDiagramEditor(diagram);
   const [historyOpen, setHistoryOpen] = useState(false);
+  const canvasRef = useRef<HTMLDivElement>(null);
 
   return (
     <div className="flex flex-1 flex-col">
       <EditorHeader
         diagram={editor.diagram}
+        content={editor.content}
         isDirty={editor.isDirty}
         isSaving={editor.isSaving}
         error={editor.error}
         onSave={editor.save}
         isHistoryOpen={historyOpen}
         onToggleHistory={() => setHistoryOpen((open) => !open)}
+        canvasRef={canvasRef}
+        onImport={editor.setContent}
       />
       <div className="flex flex-1 overflow-hidden">
-        <div className="flex flex-1 flex-col">
+        <div ref={canvasRef} className="flex flex-1 flex-col">
           {editor.diagram.kind === "SchemaDiagram" ? (
             <SchemaDiagramEditor
               content={editor.content}

--- a/frontend/src/components/EditorHeader.test.tsx
+++ b/frontend/src/components/EditorHeader.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { EditorHeader } from "./EditorHeader";
 import { Diagram } from "@/lib/types";
@@ -12,84 +13,69 @@ const diagram: Diagram = {
   updatedAt: "2026-08-01T00:00:00Z",
 };
 
+function renderHeader(overrides: Partial<Parameters<typeof EditorHeader>[0]> = {}) {
+  const canvasRef = createRef<HTMLDivElement>();
+  return render(
+    <EditorHeader
+      diagram={diagram}
+      content={diagram.content}
+      isDirty={false}
+      isSaving={false}
+      error={null}
+      onSave={vi.fn()}
+      isHistoryOpen={false}
+      onToggleHistory={vi.fn()}
+      canvasRef={canvasRef}
+      onImport={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
 describe("EditorHeader", () => {
   it("disables Save and shows Saved when clean", () => {
-    render(
-      <EditorHeader
-        diagram={diagram}
-        isDirty={false}
-        isSaving={false}
-        error={null}
-        onSave={vi.fn()}
-        isHistoryOpen={false}
-        onToggleHistory={vi.fn()}
-      />,
-    );
+    renderHeader({ isDirty: false });
     expect(screen.getByText("Save")).toBeDisabled();
     expect(screen.getByText("Saved")).toBeInTheDocument();
   });
 
   it("enables Save and shows Unsaved changes when dirty", () => {
-    render(
-      <EditorHeader
-        diagram={diagram}
-        isDirty={true}
-        isSaving={false}
-        error={null}
-        onSave={vi.fn()}
-        isHistoryOpen={false}
-        onToggleHistory={vi.fn()}
-      />,
-    );
+    renderHeader({ isDirty: true });
     expect(screen.getByText("Save")).not.toBeDisabled();
     expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
   });
 
   it("disables Save while a save is in flight", () => {
-    render(
-      <EditorHeader
-        diagram={diagram}
-        isDirty={true}
-        isSaving={true}
-        error={null}
-        onSave={vi.fn()}
-        isHistoryOpen={false}
-        onToggleHistory={vi.fn()}
-      />,
-    );
+    renderHeader({ isDirty: true, isSaving: true });
     expect(screen.getByText("Save")).toBeDisabled();
   });
 
   it("shows the error message instead of the dirty indicator when present", () => {
-    render(
-      <EditorHeader
-        diagram={diagram}
-        isDirty={true}
-        isSaving={false}
-        error="Failed to save"
-        onSave={vi.fn()}
-        isHistoryOpen={false}
-        onToggleHistory={vi.fn()}
-      />,
-    );
+    renderHeader({ isDirty: true, error: "Failed to save" });
     expect(screen.getByText("Failed to save")).toBeInTheDocument();
     expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
   });
 
   it("calls onToggleHistory when the History button is clicked", () => {
     const onToggleHistory = vi.fn();
-    render(
-      <EditorHeader
-        diagram={diagram}
-        isDirty={false}
-        isSaving={false}
-        error={null}
-        onSave={vi.fn()}
-        isHistoryOpen={false}
-        onToggleHistory={onToggleHistory}
-      />,
-    );
+    renderHeader({ onToggleHistory });
     screen.getByText("History").click();
     expect(onToggleHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows Import for a SchemaDiagram", () => {
+    renderHeader();
+    expect(screen.getByText("Import")).toBeInTheDocument();
+  });
+
+  it("hides Import for a GenericDiagram", () => {
+    renderHeader({ diagram: { ...diagram, kind: "GenericDiagram" } });
+    expect(screen.queryByText("Import")).not.toBeInTheDocument();
+  });
+
+  it("opens the import dialog from the Import button", () => {
+    renderHeader();
+    fireEvent.click(screen.getByText("Import"));
+    expect(screen.getByPlaceholderText("Paste CREATE TABLE statements...")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/EditorHeader.tsx
+++ b/frontend/src/components/EditorHeader.tsx
@@ -1,26 +1,36 @@
 "use client";
 
+import { RefObject, useState } from "react";
 import { Diagram } from "@/lib/types";
 import { AppHeader } from "./AppHeader";
+import { ExportMenu } from "./ExportMenu";
+import { ImportDialog } from "./ImportDialog";
 import { KindBadge } from "./KindBadge";
 
 export function EditorHeader({
   diagram,
+  content,
   isDirty,
   isSaving,
   error,
   onSave,
   isHistoryOpen,
   onToggleHistory,
+  canvasRef,
+  onImport,
 }: {
   diagram: Diagram;
+  content: string;
   isDirty: boolean;
   isSaving: boolean;
   error: string | null;
   onSave: () => void;
   isHistoryOpen: boolean;
   onToggleHistory: () => void;
+  canvasRef: RefObject<HTMLDivElement | null>;
+  onImport: (dbml: string) => void;
 }) {
+  const [importOpen, setImportOpen] = useState(false);
   return (
     <AppHeader
       onNavigateAway={(event) => {
@@ -52,12 +62,21 @@ export function EditorHeader({
       >
         History
       </button>
-      <button className="rounded-md border border-black/10 px-3 py-1.5 text-sm font-medium hover:bg-black/5 dark:border-white/10 dark:hover:bg-white/5">
-        Export
-      </button>
+      {diagram.kind === "SchemaDiagram" && (
+        <button
+          onClick={() => setImportOpen(true)}
+          className="rounded-md border border-black/10 px-3 py-1.5 text-sm font-medium hover:bg-black/5 dark:border-white/10 dark:hover:bg-white/5"
+        >
+          Import
+        </button>
+      )}
+      <ExportMenu diagram={diagram} content={content} isDirty={isDirty} canvasRef={canvasRef} />
       <button className="rounded-md border border-black/10 px-3 py-1.5 text-sm font-medium hover:bg-black/5 dark:border-white/10 dark:hover:bg-white/5">
         Copy link
       </button>
+      {importOpen && (
+        <ImportDialog onImport={onImport} onClose={() => setImportOpen(false)} />
+      )}
     </AppHeader>
   );
 }

--- a/frontend/src/components/ExportMenu.test.tsx
+++ b/frontend/src/components/ExportMenu.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExportMenu } from "./ExportMenu";
+import { DbmlConversionError, dbmlToSql } from "@/lib/dbml";
+import { downloadDataUrl, downloadText } from "@/lib/export";
+import { Diagram } from "@/lib/types";
+
+vi.mock("@/lib/dbml", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/dbml")>("@/lib/dbml");
+  return { ...actual, dbmlToSql: vi.fn() };
+});
+
+vi.mock("@/lib/export", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/export")>("@/lib/export");
+  return { ...actual, downloadText: vi.fn(), downloadDataUrl: vi.fn() };
+});
+
+const schemaDiagram: Diagram = {
+  shareToken: "abc",
+  title: "Orders / v2",
+  kind: "SchemaDiagram",
+  content: "Table orders {}",
+  layout: {},
+  updatedAt: "2026-08-01T00:00:00Z",
+};
+
+const genericDiagram: Diagram = {
+  ...schemaDiagram,
+  kind: "GenericDiagram",
+  content: "flowchart TD\n  Start --> End\n",
+};
+
+function renderMenu(diagram: Diagram, isDirty = false) {
+  const canvasRef = createRef<HTMLDivElement>();
+  render(
+    <div ref={canvasRef}>
+      <ExportMenu diagram={diagram} content={diagram.content} isDirty={isDirty} canvasRef={canvasRef} />
+    </div>,
+  );
+}
+
+describe("ExportMenu", () => {
+  beforeEach(() => {
+    vi.mocked(dbmlToSql).mockReset();
+    vi.mocked(downloadText).mockReset();
+    vi.mocked(downloadDataUrl).mockReset();
+  });
+
+  it("offers no SQL formats for a GenericDiagram", () => {
+    renderMenu(genericDiagram);
+    fireEvent.click(screen.getByText("Export"));
+    expect(screen.queryByText("SQL (PostgreSQL)")).not.toBeInTheDocument();
+    expect(screen.getByText("Mermaid")).toBeInTheDocument();
+  });
+
+  it("offers DBML and every SQL dialect for a SchemaDiagram", () => {
+    renderMenu(schemaDiagram);
+    fireEvent.click(screen.getByText("Export"));
+    expect(screen.getByText("DBML")).toBeInTheDocument();
+    expect(screen.getByText("SQL (PostgreSQL)")).toBeInTheDocument();
+    expect(screen.getByText("SQL (MySQL)")).toBeInTheDocument();
+    expect(screen.getByText("SQL (SQL Server)")).toBeInTheDocument();
+  });
+
+  it("calls dbmlToSql with the dialect matching the chosen format", () => {
+    vi.mocked(dbmlToSql).mockReturnValue("CREATE TABLE orders ();");
+    renderMenu(schemaDiagram);
+    fireEvent.click(screen.getByText("Export"));
+    fireEvent.click(screen.getByText("SQL (PostgreSQL)"));
+
+    expect(dbmlToSql).toHaveBeenCalledWith(schemaDiagram.content, "postgres");
+    expect(downloadText).toHaveBeenCalledWith(
+      "Orders-v2.postgres.sql",
+      "CREATE TABLE orders ();",
+      "text/plain",
+    );
+  });
+
+  it("shows an error and does not download when SQL conversion fails", () => {
+    vi.mocked(dbmlToSql).mockImplementation(() => {
+      throw new DbmlConversionError("Parse error: invalid input");
+    });
+    renderMenu(schemaDiagram);
+    fireEvent.click(screen.getByText("Export"));
+    fireEvent.click(screen.getByText("SQL (PostgreSQL)"));
+
+    expect(screen.getByText("Parse error: invalid input")).toBeInTheDocument();
+    expect(downloadText).not.toHaveBeenCalled();
+  });
+
+  it("downloads DBML straight from the buffer with no conversion", () => {
+    renderMenu(schemaDiagram);
+    fireEvent.click(screen.getByText("Export"));
+    fireEvent.click(screen.getByText("DBML"));
+
+    expect(dbmlToSql).not.toHaveBeenCalled();
+    expect(downloadText).toHaveBeenCalledWith("Orders-v2.dbml", schemaDiagram.content, "text/plain");
+  });
+
+  it("notes that unsaved changes are being exported when the buffer is dirty", () => {
+    renderMenu(schemaDiagram, true);
+    fireEvent.click(screen.getByText("Export"));
+    expect(screen.getByText("Exporting unsaved changes")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ExportMenu.tsx
+++ b/frontend/src/components/ExportMenu.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { RefObject, useState } from "react";
+import { toPng, toSvg } from "html-to-image";
+import { DbmlConversionError } from "@/lib/dbml";
+import {
+  downloadDataUrl,
+  downloadText,
+  ExportFormat,
+  exportFormatsFor,
+  filenameFor,
+  isTextFormat,
+  textContentForFormat,
+} from "@/lib/export";
+import { Diagram } from "@/lib/types";
+
+const FORMAT_LABELS: Record<ExportFormat, string> = {
+  dbml: "DBML",
+  mermaid: "Mermaid",
+  "sql-postgres": "SQL (PostgreSQL)",
+  "sql-mysql": "SQL (MySQL)",
+  "sql-mssql": "SQL (SQL Server)",
+  svg: "SVG image",
+  png: "PNG image",
+};
+
+export function ExportMenu({
+  diagram,
+  content,
+  isDirty,
+  canvasRef,
+}: {
+  diagram: Diagram;
+  content: string;
+  isDirty: boolean;
+  canvasRef: RefObject<HTMLDivElement | null>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+
+  async function handleExport(format: ExportFormat) {
+    setError(null);
+
+    if (isTextFormat(format)) {
+      try {
+        const text = textContentForFormat(format, content);
+        downloadText(filenameFor(diagram.title, format), text, "text/plain");
+        setOpen(false);
+      } catch (err) {
+        setError(err instanceof DbmlConversionError ? err.message : "Export failed");
+      }
+      return;
+    }
+
+    const node = canvasRef.current;
+    if (!node) {
+      setError("Nothing to export yet");
+      return;
+    }
+    setExporting(true);
+    try {
+      const dataUrl = format === "svg" ? await toSvg(node) : await toPng(node);
+      downloadDataUrl(filenameFor(diagram.title, format), dataUrl);
+      setOpen(false);
+    } catch {
+      setError("Export failed");
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="rounded-md border border-black/10 px-3 py-1.5 text-sm font-medium hover:bg-black/5 dark:border-white/10 dark:hover:bg-white/5"
+      >
+        Export
+      </button>
+      {open && (
+        <div className="absolute right-0 z-10 mt-1 w-56 rounded-md border border-black/10 bg-background shadow-lg dark:border-white/10">
+          {isDirty && (
+            <p className="border-b border-black/10 px-3 py-2 text-xs text-zinc-500 dark:border-white/10 dark:text-zinc-400">
+              Exporting unsaved changes
+            </p>
+          )}
+          {exportFormatsFor(diagram.kind).map((format) => (
+            <button
+              key={format}
+              onClick={() => handleExport(format)}
+              disabled={exporting}
+              className="block w-full px-3 py-2 text-left text-sm hover:bg-black/5 disabled:opacity-50 dark:hover:bg-white/5"
+            >
+              {FORMAT_LABELS[format]}
+            </button>
+          ))}
+          {error && (
+            <p className="border-t border-black/10 px-3 py-2 text-xs text-red-600 dark:border-white/10 dark:text-red-400">
+              {error}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ImportDialog.test.tsx
+++ b/frontend/src/components/ImportDialog.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ImportDialog } from "./ImportDialog";
+import { DbmlConversionError, sqlToDbml } from "@/lib/dbml";
+
+vi.mock("@/lib/dbml", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/dbml")>("@/lib/dbml");
+  return { ...actual, sqlToDbml: vi.fn() };
+});
+
+function renderDialog() {
+  const onImport = vi.fn();
+  const onClose = vi.fn();
+  render(<ImportDialog onImport={onImport} onClose={onClose} />);
+  return { onImport, onClose };
+}
+
+describe("ImportDialog", () => {
+  beforeEach(() => {
+    vi.mocked(sqlToDbml).mockReset();
+  });
+
+  it("converts pasted SQL via sqlToDbml and imports the result", () => {
+    vi.mocked(sqlToDbml).mockReturnValue("Table users {\n  id integer\n}\n");
+    const { onImport, onClose } = renderDialog();
+
+    fireEvent.change(screen.getByPlaceholderText("Paste CREATE TABLE statements..."), {
+      target: { value: "CREATE TABLE users (id INT);" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(sqlToDbml).toHaveBeenCalledWith("CREATE TABLE users (id INT);", "postgres");
+    expect(onImport).toHaveBeenCalledWith("Table users {\n  id integer\n}\n");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("imports pasted DBML as-is without calling sqlToDbml", () => {
+    const { onImport, onClose } = renderDialog();
+
+    fireEvent.click(screen.getByText("DBML"));
+    fireEvent.change(screen.getByPlaceholderText("Paste DBML..."), {
+      target: { value: "Table users {\n  id integer\n}\n" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(sqlToDbml).not.toHaveBeenCalled();
+    expect(onImport).toHaveBeenCalledWith("Table users {\n  id integer\n}\n");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows an error and leaves the buffer untouched when SQL fails to parse", () => {
+    vi.mocked(sqlToDbml).mockImplementation(() => {
+      throw new DbmlConversionError("Parse error: invalid input");
+    });
+    const { onImport, onClose } = renderDialog();
+
+    fireEvent.change(screen.getByPlaceholderText("Paste CREATE TABLE statements..."), {
+      target: { value: "not sql" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(screen.getByText("Parse error: invalid input")).toBeInTheDocument();
+    expect(onImport).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("requires some input before importing", () => {
+    const { onImport } = renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: "Import" }));
+    expect(screen.getByText("Paste or choose a .sql file first")).toBeInTheDocument();
+    expect(onImport).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ImportDialog.tsx
+++ b/frontend/src/components/ImportDialog.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { ChangeEvent, useState } from "react";
+import { DbmlConversionError, sqlToDbml } from "@/lib/dbml";
+
+type Source = "sql" | "dbml";
+
+export function ImportDialog({
+  onImport,
+  onClose,
+}: {
+  onImport: (dbml: string) => void;
+  onClose: () => void;
+}) {
+  const [source, setSource] = useState<Source>("sql");
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  function handleFile(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+    file.text().then(setText);
+  }
+
+  function handleImport() {
+    setError(null);
+    if (!text.trim()) {
+      setError(source === "sql" ? "Paste or choose a .sql file first" : "Paste or choose a .dbml file first");
+      return;
+    }
+    if (source === "dbml") {
+      onImport(text);
+      onClose();
+      return;
+    }
+    try {
+      const dbml = sqlToDbml(text, "postgres");
+      onImport(dbml);
+      onClose();
+    } catch (err) {
+      setError(err instanceof DbmlConversionError ? err.message : "Import failed");
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/30">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Import"
+        className="w-full max-w-lg rounded-lg border border-black/10 bg-background p-4 shadow-lg dark:border-white/10"
+      >
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium">Import</span>
+          <button
+            onClick={onClose}
+            className="text-xs text-zinc-500 hover:underline dark:text-zinc-400"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="mt-3 flex gap-2">
+          <button
+            onClick={() => setSource("sql")}
+            aria-pressed={source === "sql"}
+            className={`rounded-md border px-3 py-1.5 text-sm font-medium ${
+              source === "sql"
+                ? "border-black/30 dark:border-white/30"
+                : "border-black/10 dark:border-white/10"
+            }`}
+          >
+            SQL
+          </button>
+          <button
+            onClick={() => setSource("dbml")}
+            aria-pressed={source === "dbml"}
+            className={`rounded-md border px-3 py-1.5 text-sm font-medium ${
+              source === "dbml"
+                ? "border-black/30 dark:border-white/30"
+                : "border-black/10 dark:border-white/10"
+            }`}
+          >
+            DBML
+          </button>
+        </div>
+
+        <input
+          type="file"
+          accept={source === "sql" ? ".sql" : ".dbml"}
+          onChange={handleFile}
+          className="mt-3 block text-sm"
+        />
+
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={source === "sql" ? "Paste CREATE TABLE statements..." : "Paste DBML..."}
+          spellCheck={false}
+          className="mt-3 h-48 w-full resize-none rounded-md border border-black/10 bg-transparent p-2 font-mono text-sm outline-none dark:border-white/10"
+        />
+
+        {error && <p className="mt-2 text-xs text-red-600 dark:text-red-400">{error}</p>}
+
+        <div className="mt-3 flex justify-end">
+          <button
+            onClick={handleImport}
+            className="rounded-md bg-foreground px-3 py-1.5 text-sm font-medium text-background hover:opacity-90"
+          >
+            Import
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/export.test.ts
+++ b/frontend/src/lib/export.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  exportFormatsFor,
+  filenameFor,
+  isTextFormat,
+  sanitizeFilenameBase,
+  textContentForFormat,
+} from "./export";
+import { DbmlConversionError } from "./dbml";
+
+const DBML = "Table users {\n  id integer [primary key]\n  name varchar\n}\n";
+
+describe("sanitizeFilenameBase / filenameFor", () => {
+  it("keeps a simple title as-is", () => {
+    expect(sanitizeFilenameBase("Orders")).toBe("Orders");
+  });
+
+  it("replaces slashes and spaces with a safe separator", () => {
+    expect(sanitizeFilenameBase("Orders / Customers v2")).toBe("Orders-Customers-v2");
+  });
+
+  it("falls back to a default name for an empty or fully-unsafe title", () => {
+    expect(sanitizeFilenameBase("   ")).toBe("diagram");
+    expect(sanitizeFilenameBase("///")).toBe("diagram");
+  });
+
+  it("derives the filename from title and format extension", () => {
+    expect(filenameFor("Orders", "dbml")).toBe("Orders.dbml");
+    expect(filenameFor("Orders", "sql-postgres")).toBe("Orders.postgres.sql");
+    expect(filenameFor("Orders", "png")).toBe("Orders.png");
+  });
+});
+
+describe("exportFormatsFor", () => {
+  it("offers DBML and SQL dialects plus image formats for SchemaDiagram", () => {
+    const formats = exportFormatsFor("SchemaDiagram");
+    expect(formats).toContain("dbml");
+    expect(formats).toContain("sql-postgres");
+    expect(formats).toContain("sql-mysql");
+    expect(formats).toContain("sql-mssql");
+    expect(formats).toContain("svg");
+    expect(formats).toContain("png");
+    expect(formats).not.toContain("mermaid");
+  });
+
+  it("offers only Mermaid and image formats for GenericDiagram, no SQL", () => {
+    const formats = exportFormatsFor("GenericDiagram");
+    expect(formats).toEqual(["mermaid", "svg", "png"]);
+  });
+});
+
+describe("isTextFormat", () => {
+  it("treats svg and png as non-text, everything else as text", () => {
+    expect(isTextFormat("svg")).toBe(false);
+    expect(isTextFormat("png")).toBe(false);
+    expect(isTextFormat("dbml")).toBe(true);
+    expect(isTextFormat("sql-postgres")).toBe(true);
+  });
+});
+
+describe("textContentForFormat", () => {
+  it("returns the buffer as-is for dbml and mermaid", () => {
+    expect(textContentForFormat("dbml", DBML)).toBe(DBML);
+    expect(textContentForFormat("mermaid", "flowchart TD\n")).toBe("flowchart TD\n");
+  });
+
+  it("calls through to dbmlToSql with the dialect matching the format", () => {
+    const sql = textContentForFormat("sql-postgres", DBML);
+    expect(sql.toUpperCase()).toContain("CREATE TABLE");
+  });
+
+  it("throws DbmlConversionError instead of returning empty output for invalid DBML", () => {
+    expect(() => textContentForFormat("sql-postgres", "not dbml {{{")).toThrow(
+      DbmlConversionError,
+    );
+  });
+});

--- a/frontend/src/lib/export.ts
+++ b/frontend/src/lib/export.ts
@@ -1,0 +1,85 @@
+import { dbmlToSql, SqlExportDialect } from "./dbml";
+import { DiagramKind } from "./types";
+
+export type TextExportFormat = "dbml" | "mermaid" | "sql-postgres" | "sql-mysql" | "sql-mssql";
+export type ImageExportFormat = "svg" | "png";
+export type ExportFormat = TextExportFormat | ImageExportFormat;
+
+const SCHEMA_EXPORT_FORMATS: ExportFormat[] = [
+  "dbml",
+  "sql-postgres",
+  "sql-mysql",
+  "sql-mssql",
+  "svg",
+  "png",
+];
+
+const GENERIC_EXPORT_FORMATS: ExportFormat[] = ["mermaid", "svg", "png"];
+
+const SQL_DIALECT_BY_FORMAT: Record<"sql-postgres" | "sql-mysql" | "sql-mssql", SqlExportDialect> = {
+  "sql-postgres": "postgres",
+  "sql-mysql": "mysql",
+  "sql-mssql": "mssql",
+};
+
+const EXTENSION_BY_FORMAT: Record<ExportFormat, string> = {
+  dbml: "dbml",
+  mermaid: "mmd",
+  "sql-postgres": "postgres.sql",
+  "sql-mysql": "mysql.sql",
+  "sql-mssql": "mssql.sql",
+  svg: "svg",
+  png: "png",
+};
+
+export function exportFormatsFor(kind: DiagramKind): ExportFormat[] {
+  return kind === "SchemaDiagram" ? SCHEMA_EXPORT_FORMATS : GENERIC_EXPORT_FORMATS;
+}
+
+export function isTextFormat(format: ExportFormat): format is TextExportFormat {
+  return format !== "svg" && format !== "png";
+}
+
+export function sanitizeFilenameBase(title: string): string {
+  const cleaned = title
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return cleaned || "diagram";
+}
+
+export function filenameFor(title: string, format: ExportFormat): string {
+  return `${sanitizeFilenameBase(title)}.${EXTENSION_BY_FORMAT[format]}`;
+}
+
+/**
+ * Resolves the exportable text for a TextExportFormat. dbml/mermaid come
+ * straight from the buffer; sql-* dialects go through dbmlToSql. Throws
+ * DbmlConversionError on invalid DBML, same as the underlying conversion.
+ */
+export function textContentForFormat(format: TextExportFormat, content: string): string {
+  if (format === "dbml" || format === "mermaid") {
+    return content;
+  }
+  return dbmlToSql(content, SQL_DIALECT_BY_FORMAT[format]);
+}
+
+export function downloadText(filename: string, content: string, mimeType: string): void {
+  downloadBlob(filename, new Blob([content], { type: mimeType }));
+}
+
+export function downloadDataUrl(filename: string, dataUrl: string): void {
+  const link = document.createElement("a");
+  link.href = dataUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+function downloadBlob(filename: string, blob: Blob): void {
+  const url = URL.createObjectURL(blob);
+  downloadDataUrl(filename, url);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- New `frontend/src/lib/export.ts`: pure helpers — filename sanitisation/derivation, the format list per Diagram kind, and text-format content resolution (dbml/mermaid passthrough, sql-* through `dbmlToSql`)
- New `ExportMenu.tsx`: dropdown wired into `EditorHeader`, offering `dbml`/`sql-postgres`/`sql-mysql`/`sql-mssql`/`svg`/`png` for SchemaDiagram and `mermaid`/`svg`/`png` for GenericDiagram. Exports the **live buffer** (not last-saved), with a non-blocking "Exporting unsaved changes" note when dirty rather than silently exporting stale content or forcing a save first
- New `ImportDialog.tsx`: SchemaDiagram-only, reachable from a new "Import" header button, paste-or-upload for `.sql` (via `sqlToDbml`) or `.dbml` (used as-is); replaces the buffer and marks it dirty without saving
- New dependency: `html-to-image`, used for `svg`/`png` capture of the rendered canvas

## Deviations from the issue text (both due to facts discovered after #18 was filed)
- **No `sql-sqlite`**: `frontend/src/lib/dbml.ts` (landed in #11) already documents that `@dbml/core`'s sqlite dialect silently returns empty output on both import and export, so it's excluded from `SQL_EXPORT_DIALECTS`/`SQL_IMPORT_DIALECTS`. This PR follows that existing exclusion rather than reintroducing an unusable format.
- **SVG/PNG capture uses `html-to-image` on the rendered DOM node, not a hand-rolled "serialise SVG string → inline styles → rasterise via canvas" pipeline.** react-flow (`@xyflow/react`) renders table nodes as HTML `<div>`s, not SVG — only the edges layer is SVG — so there is no single "the rendered SVG" element to serialise for SchemaDiagram as the issue assumed. `html-to-image` is the library xyflow's own docs recommend for exactly this "download as image" case, and it internally handles the same font/stylesheet-inlining concern the issue's Notes section called out.

## Test plan
- [x] `npx eslint`, `next typegen && npx tsc --noEmit`, `next build` — all clean
- [x] `npx vitest run` — 92/92 passing, including new `export.test.ts`, `ExportMenu.test.tsx`, `ImportDialog.test.tsx`, and `EditorHeader.test.tsx` additions
- [x] Full Playwright suite (12 specs, including new `e2e/export.spec.ts`) against a real backend+Postgres on an isolated Docker network, `CI=true` (single worker + 1 retry per #46) — 12/12 passing (one pre-existing timing-sensitive spec needed its already-expected retry, same class #46 fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w