### PR TITLE
Render DBML relationships as field-level edges on the SchemaDiagram canvas

### DIFF
--- a/frontend/e2e/relationships.spec.ts
+++ b/frontend/e2e/relationships.spec.ts
@@ -1,0 +1,69 @@
+import { expect, Locator, Page, test } from "@playwright/test";
+
+async function dragNode(page: Page, node: Locator, dx: number, dy: number) {
+  const box = await node.boundingBox();
+  if (!box) throw new Error("node has no bounding box");
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width / 2 + dx, box.y + box.height / 2 + dy, { steps: 10 });
+  await page.mouse.up();
+}
+
+async function newSchemaDiagram(page: Page) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "SchemaDiagram" }).click();
+  await expect(page).toHaveURL(/\/d\/[^/]+$/);
+}
+
+test("a Ref renders as an edge anchored at the two related tables", async ({ page }) => {
+  await newSchemaDiagram(page);
+
+  await page.locator("textarea").fill(
+    "Table orders {\n  id integer [primary key]\n  customer_id integer\n}\n\nTable customers {\n  id integer [primary key]\n}\n\nRef: orders.customer_id > customers.id\n",
+  );
+
+  await expect(page.locator(".react-flow__node")).toHaveCount(2);
+  await expect(page.locator(".react-flow__edge")).toHaveCount(1);
+});
+
+test("dragging a table keeps the edge attached and re-routes it", async ({ page }) => {
+  await newSchemaDiagram(page);
+
+  await page.locator("textarea").fill(
+    "Table orders {\n  id integer [primary key]\n  customer_id integer\n}\n\nTable customers {\n  id integer [primary key]\n}\n\nRef: orders.customer_id > customers.id\n",
+  );
+  const edgePath = page.locator(".react-flow__edge-path").first();
+  await expect(edgePath).toBeVisible();
+  const pathBefore = await edgePath.getAttribute("d");
+
+  const orders = page.locator(".react-flow__node", { hasText: "orders" });
+  await dragNode(page, orders, 150, 120);
+
+  await expect(page.locator(".react-flow__edge")).toHaveCount(1);
+  const pathAfter = await edgePath.getAttribute("d");
+  expect(pathAfter).not.toBe(pathBefore);
+});
+
+test("a self-referencing Ref renders as a self-loop without breaking the canvas", async ({ page }) => {
+  await newSchemaDiagram(page);
+
+  await page.locator("textarea").fill(
+    "Table orders {\n  id integer [primary key]\n  parent_order_id integer\n}\n\nRef: orders.parent_order_id > orders.id\n",
+  );
+
+  await expect(page.locator(".react-flow__node")).toHaveCount(1);
+  await expect(page.locator(".react-flow__edge")).toHaveCount(1);
+});
+
+test("a Ref naming a table that doesn't exist surfaces an error naming it, without crashing", async ({
+  page,
+}) => {
+  await newSchemaDiagram(page);
+
+  await page.locator("textarea").fill(
+    "Table orders {\n  id integer [primary key]\n  customer_id integer\n}\n\nRef: orders.customer_id > missing_table.id\n",
+  );
+
+  await expect(page.getByText(/missing_table/)).toBeVisible();
+});

--- a/frontend/src/components/RelationshipEdge.tsx
+++ b/frontend/src/components/RelationshipEdge.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { BaseEdge, EdgeLabelRenderer, EdgeProps, getBezierPath } from "@xyflow/react";
+import { Cardinality } from "@/lib/relationships";
+
+const SELF_LOOP_OFFSET = 70;
+
+function selfLoopPath(sourceX: number, sourceY: number, targetX: number, targetY: number): string {
+  return `M ${sourceX} ${sourceY} C ${sourceX + SELF_LOOP_OFFSET} ${sourceY}, ${targetX + SELF_LOOP_OFFSET} ${targetY}, ${targetX} ${targetY}`;
+}
+
+function CardinalityMarker({ label, x, y }: { label: Cardinality; x: number; y: number }) {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        transform: `translate(-50%, -50%) translate(${x}px, ${y}px)`,
+        pointerEvents: "none",
+      }}
+      className="rounded border border-black/10 bg-background px-1 text-[10px] font-semibold text-zinc-600 dark:border-white/10 dark:text-zinc-300"
+    >
+      {label === "1" ? "1" : "∞"}
+    </div>
+  );
+}
+
+export function RelationshipEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style,
+  data,
+}: EdgeProps) {
+  const sourceCardinality = (data?.sourceCardinality as Cardinality | undefined) ?? "*";
+  const targetCardinality = (data?.targetCardinality as Cardinality | undefined) ?? "*";
+  const selfReferencing = Boolean(data?.selfReferencing);
+
+  const [path] = selfReferencing
+    ? [selfLoopPath(sourceX, sourceY, targetX, targetY)]
+    : getBezierPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition });
+
+  const midX = selfReferencing
+    ? Math.max(sourceX, targetX) + SELF_LOOP_OFFSET
+    : (sourceX + targetX) / 2;
+  const midY = (sourceY + targetY) / 2;
+
+  return (
+    <>
+      <BaseEdge id={id} path={path} style={style} />
+      <EdgeLabelRenderer>
+        <CardinalityMarker
+          label={sourceCardinality}
+          x={selfReferencing ? sourceX + 16 : sourceX + (midX - sourceX) * 0.15}
+          y={selfReferencing ? sourceY : sourceY + (midY - sourceY) * 0.15}
+        />
+        <CardinalityMarker
+          label={targetCardinality}
+          x={selfReferencing ? targetX + 16 : targetX + (midX - targetX) * 0.15}
+          y={selfReferencing ? targetY : targetY + (midY - targetY) * 0.15}
+        />
+      </EdgeLabelRenderer>
+    </>
+  );
+}

--- a/frontend/src/components/SchemaDiagramEditor.test.tsx
+++ b/frontend/src/components/SchemaDiagramEditor.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SchemaDiagramEditor } from "./SchemaDiagramEditor";
+
+function renderEditor(content: string) {
+  return render(
+    <SchemaDiagramEditor content={content} onContentChange={vi.fn()} layout={{}} onLayoutChange={vi.fn()} />,
+  );
+}
+
+describe("SchemaDiagramEditor relationships", () => {
+  it("gives every field row a source and target Handle so edges can anchor at field granularity", () => {
+    // Actual .react-flow__edge presence needs real layout/geometry (viewport
+    // transforms, handle bounding rects) that jsdom doesn't provide even with
+    // ResizeObserver/DOMMatrixReadOnly stubbed — that's covered in
+    // e2e/relationships.spec.ts against a real browser instead. This checks
+    // the piece that *is* meaningfully jsdom-testable: every field is wired
+    // as a connectable endpoint in both directions.
+    renderEditor(
+      "Table orders {\n  id integer [primary key]\n  customer_id integer\n}\nTable customers {\n  id integer [primary key]\n}\nRef: orders.customer_id > customers.id\n",
+    );
+    expect(document.querySelector('[data-handleid="customer_id"][data-handlepos="left"]')).not.toBeNull();
+    expect(document.querySelector('[data-handleid="customer_id"][data-handlepos="right"]')).not.toBeNull();
+    expect(document.querySelector('[data-handleid="id"][data-nodeid="customers"]')).not.toBeNull();
+  });
+
+  it("names the broken reference instead of crashing when a Ref points at a table that doesn't exist", () => {
+    // @dbml/core validates Ref endpoints at parse time (confirmed directly
+    // against the library), so this never reaches buildRelationshipEdges's
+    // own dangling-flagging in practice — it surfaces through the existing
+    // whole-document parse-error path instead, whose message already names
+    // the missing table. relationships.test.ts covers dangling-detection
+    // itself as pure data, per a parser that didn't already reject it.
+    renderEditor(
+      "Table orders {\n  id integer [primary key]\n  customer_id integer\n}\nRef: orders.customer_id > missing_table.id\n",
+    );
+    expect(screen.getByText(/missing_table/)).toBeInTheDocument();
+    expect(document.querySelector(".react-flow__node")).toBeNull();
+  });
+
+  it("parses and renders a self-referencing Ref's table without treating it as a broken reference", () => {
+    renderEditor(
+      "Table orders {\n  id integer [primary key]\n  parent_order_id integer\n}\nRef: orders.parent_order_id > orders.id\n",
+    );
+    expect(document.querySelector('[data-testid="rf__node-orders"]')).not.toBeNull();
+    expect(screen.queryByText(/Broken reference/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/SchemaDiagramEditor.tsx
+++ b/frontend/src/components/SchemaDiagramEditor.tsx
@@ -5,55 +5,108 @@ import {
   applyNodeChanges,
   Background,
   Controls,
+  Handle,
   Node,
   NodeChange,
+  NodeProps,
+  NodeTypes,
+  Position,
   ReactFlow,
   ReactFlowProvider,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { Parser } from "@dbml/core";
 import { mergeLayout } from "@/lib/layout";
-import { Position } from "@/lib/types";
+import { buildRelationshipEdges, RelationshipEdge as RelationshipEdgeData } from "@/lib/relationships";
+import { Position as LayoutPosition } from "@/lib/types";
+import { RelationshipEdge } from "./RelationshipEdge";
+
+interface TableNodeData extends Record<string, unknown> {
+  tableName: string;
+  fields: { name: string; typeName: string }[];
+}
+
+function TableNode({ data }: NodeProps<Node<TableNodeData>>) {
+  return (
+    <div
+      style={{
+        border: "1px solid rgba(0,0,0,0.1)",
+        borderRadius: 8,
+        width: 220,
+      }}
+      className="bg-background text-left"
+    >
+      <div className="border-b border-black/10 px-2 py-1 text-sm font-semibold dark:border-white/10">
+        {data.tableName}
+      </div>
+      <div className="px-2 py-1">
+        {data.fields.map((field) => (
+          <div key={field.name} className="relative text-xs">
+            <Handle
+              type="target"
+              position={Position.Left}
+              id={field.name}
+              style={{ top: "50%", background: "transparent", border: "none" }}
+            />
+            {field.name} <span className="text-zinc-500">{field.typeName}</span>
+            <Handle
+              type="source"
+              position={Position.Right}
+              id={field.name}
+              style={{ top: "50%", background: "transparent", border: "none" }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const nodeTypes: NodeTypes = { tableNode: TableNode };
+const edgeTypes = { relationship: RelationshipEdge };
 
 function tablesToNodes(
   dbml: string,
-  layout: Record<string, Position>,
-): { nodes: Node[]; error: string | null; tableNames: string[] } {
+  layout: Record<string, LayoutPosition>,
+): {
+  nodes: Node[];
+  edges: RelationshipEdgeData[];
+  error: string | null;
+  tableNames: string[];
+} {
   try {
     const database = new Parser().parse(dbml, "dbml");
     const tables = database.schemas[0]?.tables ?? [];
+    const refs = database.schemas[0]?.refs ?? [];
     const tableNames = tables.map((table) => table.name);
     const positions = mergeLayout(tableNames, layout);
     const nodes: Node[] = tables.map((table) => ({
       id: table.name,
+      type: "tableNode",
       position: positions[table.name],
       data: {
-        label: (
-          <div className="text-left">
-            <div className="border-b border-black/10 px-2 py-1 text-sm font-semibold dark:border-white/10">
-              {table.name}
-            </div>
-            <div className="px-2 py-1">
-              {table.fields.map((field) => (
-                <div key={field.name} className="text-xs">
-                  {field.name}{" "}
-                  <span className="text-zinc-500">{field.type.type_name}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-        ),
-      },
-      style: {
-        border: "1px solid rgba(0,0,0,0.1)",
-        borderRadius: 8,
-        padding: 0,
-        width: 220,
+        tableName: table.name,
+        fields: table.fields.map((field) => ({ name: field.name, typeName: field.type.type_name })),
       },
     }));
-    return { nodes, error: null, tableNames };
+    const edges = buildRelationshipEdges(
+      tables.map((table) => ({ name: table.name, fields: table.fields.map((field) => ({ name: field.name })) })),
+      refs.map((ref) => ({
+        endpoints: ref.endpoints.map((endpoint) => ({
+          tableName: endpoint.tableName,
+          fieldNames: endpoint.fieldNames,
+          relation: endpoint.relation,
+        })),
+      })),
+    );
+    return { nodes, edges, error: null, tableNames };
   } catch (err) {
-    return { nodes: [], error: err instanceof Error ? err.message : "Invalid DBML", tableNames: [] };
+    return {
+      nodes: [],
+      edges: [],
+      error: err instanceof Error ? err.message : "Invalid DBML",
+      tableNames: [],
+    };
   }
 }
 
@@ -65,20 +118,37 @@ export function SchemaDiagramEditor({
 }: {
   content: string;
   onContentChange: (content: string) => void;
-  layout: Record<string, Position>;
-  onLayoutChange: (layout: Record<string, Position>) => void;
+  layout: Record<string, LayoutPosition>;
+  onLayoutChange: (layout: Record<string, LayoutPosition>) => void;
 }) {
-  const { nodes, error, tableNames } = useMemo(
+  const { nodes, edges, error, tableNames } = useMemo(
     () => tablesToNodes(content, layout),
     [content, layout],
   );
+
+  const danglingEdges = edges.filter((edge) => edge.dangling);
+  const flowEdges = edges
+    .filter((edge) => !edge.dangling)
+    .map((edge) => ({
+      id: edge.id,
+      type: "relationship",
+      source: edge.source,
+      sourceHandle: edge.sourceHandle,
+      target: edge.target,
+      targetHandle: edge.targetHandle,
+      data: {
+        sourceCardinality: edge.sourceCardinality,
+        targetCardinality: edge.targetCardinality,
+        selfReferencing: edge.selfReferencing,
+      },
+    }));
 
   function handleNodesChange(changes: NodeChange[]) {
     if (!changes.some((change) => change.type === "position")) {
       return;
     }
     const updatedNodes = applyNodeChanges(changes, nodes);
-    const nextLayout: Record<string, Position> = {};
+    const nextLayout: Record<string, LayoutPosition> = {};
     for (const node of updatedNodes) {
       if (tableNames.includes(node.id)) {
         nextLayout[node.id] = { x: node.position.x, y: node.position.y };
@@ -95,16 +165,34 @@ export function SchemaDiagramEditor({
         spellCheck={false}
         className="h-full resize-none border-r border-black/10 bg-transparent p-4 font-mono text-sm outline-none dark:border-white/10"
       />
-      <div className="relative h-full">
+      <div className="relative flex h-full flex-col">
         {error ? (
           <div className="p-4 text-sm text-red-600 dark:text-red-400">{error}</div>
         ) : (
-          <ReactFlowProvider>
-            <ReactFlow nodes={nodes} edges={[]} onNodesChange={handleNodesChange} fitView>
-              <Background />
-              <Controls />
-            </ReactFlow>
-          </ReactFlowProvider>
+          <>
+            {danglingEdges.length > 0 && (
+              <div className="border-b border-amber-400/40 bg-amber-50 px-3 py-1.5 text-xs text-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
+                {danglingEdges.map((edge) => (
+                  <div key={edge.id}>Broken reference: {edge.danglingReason}</div>
+                ))}
+              </div>
+            )}
+            <div className="relative flex-1">
+              <ReactFlowProvider>
+                <ReactFlow
+                  nodes={nodes}
+                  edges={flowEdges}
+                  nodeTypes={nodeTypes}
+                  edgeTypes={edgeTypes}
+                  onNodesChange={handleNodesChange}
+                  fitView
+                >
+                  <Background />
+                  <Controls />
+                </ReactFlow>
+              </ReactFlowProvider>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/lib/relationships.test.ts
+++ b/frontend/src/lib/relationships.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { buildRelationshipEdges, RelationshipRef, RelationshipTable } from "./relationships";
+
+const orders: RelationshipTable = {
+  name: "orders",
+  fields: [{ name: "id" }, { name: "customer_id" }, { name: "parent_order_id" }],
+};
+const customers: RelationshipTable = {
+  name: "customers",
+  fields: [{ name: "id" }],
+};
+
+function ref(
+  sourceTable: string,
+  sourceField: string,
+  sourceRelation: string,
+  targetTable: string,
+  targetField: string,
+  targetRelation: string,
+): RelationshipRef {
+  return {
+    endpoints: [
+      { tableName: sourceTable, fieldNames: [sourceField], relation: sourceRelation },
+      { tableName: targetTable, fieldNames: [targetField], relation: targetRelation },
+    ],
+  };
+}
+
+describe("buildRelationshipEdges", () => {
+  it("maps a one-to-many Ref to one edge with 1/* cardinality on the correct ends", () => {
+    const edges = buildRelationshipEdges(
+      [orders, customers],
+      [ref("orders", "customer_id", "*", "customers", "id", "1")],
+    );
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toMatchObject({
+      source: "orders",
+      sourceHandle: "customer_id",
+      sourceCardinality: "*",
+      target: "customers",
+      targetHandle: "id",
+      targetCardinality: "1",
+      dangling: false,
+      selfReferencing: false,
+    });
+  });
+
+  it("maps a one-to-one Ref to 1/1 cardinality on both ends", () => {
+    const edges = buildRelationshipEdges(
+      [orders, customers],
+      [ref("orders", "customer_id", "1", "customers", "id", "1")],
+    );
+    expect(edges[0].sourceCardinality).toBe("1");
+    expect(edges[0].targetCardinality).toBe("1");
+  });
+
+  it("maps a many-to-many Ref to */* cardinality on both ends", () => {
+    const edges = buildRelationshipEdges(
+      [orders, customers],
+      [ref("orders", "customer_id", "*", "customers", "id", "*")],
+    );
+    expect(edges[0].sourceCardinality).toBe("*");
+    expect(edges[0].targetCardinality).toBe("*");
+  });
+
+  it("flags a Ref naming a table absent from the parsed tables as dangling", () => {
+    const edges = buildRelationshipEdges(
+      [orders],
+      [ref("orders", "customer_id", "*", "customers", "id", "1")],
+    );
+    expect(edges[0].dangling).toBe(true);
+    expect(edges[0].danglingReason).toContain("customers");
+  });
+
+  it("flags a Ref naming a field absent from an existing table as dangling", () => {
+    const edges = buildRelationshipEdges(
+      [orders, customers],
+      [ref("orders", "nonexistent_id", "*", "customers", "id", "1")],
+    );
+    expect(edges[0].dangling).toBe(true);
+    expect(edges[0].danglingReason).toContain("nonexistent_id");
+  });
+
+  it("flags a self-referencing Ref for self-loop rendering, not as dangling", () => {
+    const edges = buildRelationshipEdges(
+      [orders],
+      [ref("orders", "parent_order_id", "*", "orders", "id", "1")],
+    );
+    expect(edges[0].selfReferencing).toBe(true);
+    expect(edges[0].dangling).toBe(false);
+  });
+
+  it("produces no edges and no dangling flags for an empty refs list", () => {
+    expect(buildRelationshipEdges([orders, customers], [])).toEqual([]);
+  });
+
+  it("keeps multiple Refs between the same two tables as distinct edges", () => {
+    const edges = buildRelationshipEdges(
+      [orders, customers],
+      [
+        ref("orders", "customer_id", "*", "customers", "id", "1"),
+        ref("customers", "id", "1", "orders", "customer_id", "*"),
+      ],
+    );
+    expect(edges).toHaveLength(2);
+    expect(new Set(edges.map((e) => e.id)).size).toBe(2);
+  });
+});

--- a/frontend/src/lib/relationships.ts
+++ b/frontend/src/lib/relationships.ts
@@ -1,0 +1,81 @@
+export type Cardinality = "1" | "*";
+
+export interface RelationshipTable {
+  name: string;
+  fields: { name: string }[];
+}
+
+export interface RelationshipRefEndpoint {
+  tableName: string;
+  fieldNames: string[];
+  relation: string;
+}
+
+export interface RelationshipRef {
+  endpoints: RelationshipRefEndpoint[];
+}
+
+export interface RelationshipEdge {
+  id: string;
+  source: string;
+  sourceHandle: string;
+  sourceCardinality: Cardinality;
+  target: string;
+  targetHandle: string;
+  targetCardinality: Cardinality;
+  selfReferencing: boolean;
+  dangling: boolean;
+  danglingReason?: string;
+}
+
+function cardinalityOf(relation: string): Cardinality {
+  return relation === "1" ? "1" : "*";
+}
+
+function describeMissing(endpoint: RelationshipRefEndpoint, table: RelationshipTable | undefined): string | null {
+  const fieldName = endpoint.fieldNames[0];
+  if (!table) {
+    return `table "${endpoint.tableName}" not found`;
+  }
+  if (!table.fields.some((field) => field.name === fieldName)) {
+    return `field "${endpoint.tableName}.${fieldName}" not found`;
+  }
+  return null;
+}
+
+/**
+ * Maps parsed DBML refs to field-level edge descriptors. Every Ref becomes
+ * exactly one edge, even when it names a table/field that doesn't currently
+ * exist (dangling: true) or references the same table on both ends
+ * (selfReferencing: true) — callers decide how to render those, this stays
+ * plain data so it's testable without react-flow.
+ */
+export function buildRelationshipEdges(
+  tables: RelationshipTable[],
+  refs: RelationshipRef[],
+): RelationshipEdge[] {
+  const tablesByName = new Map(tables.map((table) => [table.name, table]));
+
+  return refs.map((ref, index) => {
+    const [sourceEndpoint, targetEndpoint] = ref.endpoints;
+    const sourceTable = tablesByName.get(sourceEndpoint.tableName);
+    const targetTable = tablesByName.get(targetEndpoint.tableName);
+
+    const reasons = [sourceEndpoint, targetEndpoint]
+      .map((endpoint, i) => describeMissing(endpoint, i === 0 ? sourceTable : targetTable))
+      .filter((reason): reason is string => reason !== null);
+
+    return {
+      id: `ref-${index}-${sourceEndpoint.tableName}.${sourceEndpoint.fieldNames[0]}-${targetEndpoint.tableName}.${targetEndpoint.fieldNames[0]}`,
+      source: sourceEndpoint.tableName,
+      sourceHandle: sourceEndpoint.fieldNames[0],
+      sourceCardinality: cardinalityOf(sourceEndpoint.relation),
+      target: targetEndpoint.tableName,
+      targetHandle: targetEndpoint.fieldNames[0],
+      targetCardinality: cardinalityOf(targetEndpoint.relation),
+      selfReferencing: sourceEndpoint.tableName === targetEndpoint.tableName,
+      dangling: reasons.length > 0,
+      danglingReason: reasons.length > 0 ? reasons.join("; ") : undefined,
+    };
+  });
+}

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,1 +1,42 @@
 import "@testing-library/jest-dom";
+
+// react-flow (used by SchemaDiagramEditor) measures nodes via ResizeObserver,
+// which jsdom doesn't implement; without a stub, mounting it throws
+// "ResizeObserver is not defined". Real edge rendering still needs actual
+// browser layout geometry jsdom can't provide even with this stubbed, so
+// that behavior is covered by e2e/relationships.spec.ts instead.
+class ResizeObserverStub {
+  #callback: ResizeObserverCallback;
+  constructor(callback: ResizeObserverCallback) {
+    this.#callback = callback;
+  }
+  observe(target: Element) {
+    const rect = { x: 0, y: 0, width: 220, height: 100, top: 0, left: 0, bottom: 100, right: 220 };
+    const entry = { target, contentRect: rect } as unknown as ResizeObserverEntry;
+    this.#callback([entry], this as unknown as ResizeObserver);
+  }
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
+
+class DOMMatrixReadOnlyStub {
+  m22 = 1;
+}
+// @ts-expect-error jsdom doesn't implement DOMMatrixReadOnly, react-flow's viewport math needs a stand-in
+globalThis.DOMMatrixReadOnly ??= DOMMatrixReadOnlyStub;
+
+// jsdom's getBoundingClientRect() is always zero-sized, which react-flow
+// treats as "not yet measured" and never renders edges for. Give every
+// element a plausible non-zero rect so nodes/handles measure as visible.
+Element.prototype.getBoundingClientRect = () => ({
+  x: 0,
+  y: 0,
+  width: 220,
+  height: 100,
+  top: 0,
+  left: 0,
+  bottom: 100,
+  right: 220,
+  toJSON() {},
+});


### PR DESCRIPTION
## Summary
- New `frontend/src/lib/relationships.ts`: pure mapping from parsed DBML `refs`/`tables` to edge descriptors (`{id, source, sourceHandle, sourceCardinality, target, targetHandle, targetCardinality, selfReferencing, dangling, danglingReason}`), no react-flow/Next.js imports, matching the pattern set by `layout.ts` in #16
- `SchemaDiagramEditor.tsx`: replaces the flat `data.label` node with a custom `tableNode` type that renders a `<Handle>` pair per field row (anchoring edges at field granularity), and builds `edges` from `buildRelationshipEdges` instead of the hardcoded `[]`
- New `RelationshipEdge.tsx`: custom edge type drawing `1`/`∞` cardinality markers at each end, with a dedicated self-loop path (a bulging cubic curve) instead of react-flow's default bezier degenerating when `source === target`
- Dangling refs render as a small amber banner naming the broken reference above the canvas, without touching `nodes`/`edges`

## Deviations from the issue text (both verified directly against the libraries, not assumed)
- **A dangling ref (missing table/field) can't actually reach `SchemaDiagramEditor`'s per-edge dangling path in practice.** `@dbml/core`'s `Parser().parse(dbml, "dbml")` validates every `Ref`'s table/field at parse time and throws (e.g. `Can't find field "x" in table "y"`) rather than returning a ref that references something absent — confirmed by running the parser directly. So a typo'd table/field fails the *whole* document's parse (the existing all-or-nothing `error` state, already pre-existing behavior for any DBML syntax error), not just that one ref. The parser's own error message does name the broken reference, so the spirit of the requirement holds, but "without blocking rendering of the rest of the diagram" isn't achievable without reimplementing ref validation ourselves — out of scope here. `relationships.ts`'s dangling-detection is still implemented and unit-tested exactly as the issue's test list asks (as pure data against hand-built fixtures), since it's correct, cheap, and forward-compatible if that changes.
- **Real edge/self-loop rendering isn't verifiable in jsdom/vitest even with `ResizeObserver`/`DOMMatrixReadOnly` polyfilled** (added to `vitest.setup.ts`) — react-flow's edge geometry ultimately depends on real layout (`getBoundingClientRect` on handles, viewport transforms) that jsdom doesn't compute. `SchemaDiagramEditor.test.tsx` covers what jsdom *can* verify (a Handle per field row, self-referencing refs not being flagged dangling); actual edge/self-loop/drag-follow rendering is covered by a new `e2e/relationships.spec.ts` against a real browser instead.

## Test plan
- [x] `npx eslint`, `next typegen && npx tsc --noEmit`, `next build` — all clean
- [x] `npx vitest run` — 103/103 passing, including new `relationships.test.ts` (8 cases matching the issue's spec) and `SchemaDiagramEditor.test.tsx`
- [x] Full Playwright suite (16 specs, including new `e2e/relationships.spec.ts`: edge renders between related tables, edge re-routes on drag, self-loop renders without breaking the canvas, missing-table Ref surfaces its error) against a real backend+Postgres on an isolated Docker network, `CI=true` — 16/16 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w