### PR TITLE
Add relationship hover-highlight, click-to-jump, and color-coding by type

### DIFF
--- a/frontend/e2e/relationships.spec.ts
+++ b/frontend/e2e/relationships.spec.ts
@@ -67,3 +67,98 @@ test("a Ref naming a table that doesn't exist surfaces an error naming it, witho
 
   await expect(page.getByText(/missing_table/)).toBeVisible();
 });
+
+const THREE_TABLE_DBML =
+  "Table orders {\n  id integer [primary key]\n  customer_id integer\n}\n\nTable customers {\n  id integer [primary key]\n}\n\nTable unrelated {\n  id integer [primary key]\n}\n\nRef: orders.customer_id > customers.id\n";
+
+test("hovering a table highlights its connection and dims unrelated tables", async ({ page }) => {
+  await newSchemaDiagram(page);
+  await page.locator("textarea").fill(THREE_TABLE_DBML);
+
+  const orders = page.locator('[data-testid="table-node-orders"]');
+  const customers = page.locator('[data-testid="table-node-customers"]');
+  const unrelated = page.locator('[data-testid="table-node-unrelated"]');
+
+  await orders.hover();
+  await expect(unrelated).toHaveCSS("opacity", "0.4");
+  await expect(customers).not.toHaveCSS("opacity", "0.4");
+
+  await page.mouse.move(0, 0);
+  await expect(unrelated).not.toHaveCSS("opacity", "0.4");
+});
+
+test("clicking a foreign-key field pans the canvas toward the referenced table and highlights it", async ({
+  page,
+}) => {
+  await newSchemaDiagram(page);
+  await page.locator("textarea").fill(THREE_TABLE_DBML);
+
+  const viewport = page.locator(".react-flow__viewport");
+  const transformBefore = await viewport.getAttribute("style");
+
+  await page.locator('[data-testid="field-orders-customer_id"]').click();
+
+  await expect(page.locator('[data-testid="table-node-customers"]')).toHaveCSS(
+    "border-color",
+    "rgb(37, 99, 235)",
+  );
+  await expect
+    .poll(async () => viewport.getAttribute("style"))
+    .not.toBe(transformBefore);
+});
+
+test("clicking a non-FK field does not pan the canvas or highlight anything", async ({ page }) => {
+  await newSchemaDiagram(page);
+  await page.locator("textarea").fill(THREE_TABLE_DBML);
+
+  await page.locator('[data-testid="field-orders-id"]').click();
+
+  await expect(page.locator('[data-testid="table-node-customers"]')).not.toHaveCSS(
+    "border-color",
+    "rgb(37, 99, 235)",
+  );
+});
+
+test("relationship edges of different types render with different colors, and the legend is visible", async ({
+  page,
+}) => {
+  await newSchemaDiagram(page);
+  await page.locator("textarea").fill(
+    "Table orders {\n  id integer [primary key]\n  customer_id integer\n  ship_customer_id integer\n}\n\nTable customers {\n  id integer [primary key]\n}\n\nRef: orders.customer_id > customers.id\nRef: orders.ship_customer_id - customers.id\n",
+  );
+
+  await expect(page.locator(".react-flow__edge-path")).toHaveCount(2);
+  const strokes = await page.locator(".react-flow__edge-path").evaluateAll((paths) =>
+    paths.map((p) => getComputedStyle(p).stroke),
+  );
+  expect(new Set(strokes).size).toBe(2);
+
+  await expect(page.getByText("One-to-many")).toBeVisible();
+  await expect(page.getByText("One-to-one")).toBeVisible();
+  await expect(page.getByText("Many-to-many")).toBeVisible();
+});
+
+test("dragging a table still works after hovering it (hover doesn't swallow the drag)", async ({
+  page,
+  request,
+}) => {
+  await newSchemaDiagram(page);
+  const token = page.url().split("/d/")[1];
+  await page.locator("textarea").fill(THREE_TABLE_DBML);
+
+  const orders = page.locator('[data-testid="table-node-orders"]');
+  await orders.hover();
+  const box = await orders.boundingBox();
+  if (!box) throw new Error("node has no bounding box");
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width / 2 + 140, box.y + box.height / 2 + 90, { steps: 10 });
+  await page.mouse.up();
+
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(page.getByText("Saved")).toBeVisible();
+
+  const body = await (await request.get(`/api/diagrams/${token}`)).json();
+  expect(body.layout.orders).toBeDefined();
+  expect(body.layout.orders).not.toEqual({ x: 0, y: 0 });
+});

--- a/frontend/src/components/RelationshipEdge.tsx
+++ b/frontend/src/components/RelationshipEdge.tsx
@@ -1,21 +1,59 @@
 "use client";
 
+import { createContext, useContext } from "react";
 import { BaseEdge, EdgeLabelRenderer, EdgeProps, getBezierPath } from "@xyflow/react";
-import { Cardinality } from "@/lib/relationships";
+import { Cardinality, RelationshipType } from "@/lib/relationships";
 
 const SELF_LOOP_OFFSET = 70;
+
+export const RELATIONSHIP_TYPE_COLORS: Record<RelationshipType, string> = {
+  "one-to-one": "#2563eb",
+  "one-to-many": "#16a34a",
+  "many-to-many": "#dc2626",
+};
+
+/**
+ * Hover/click-to-jump highlight state, shared via context rather than baked
+ * into react-flow's `nodes`/`edges` props. Recreating those arrays/objects
+ * on every hover was observed to abort an in-progress drag (react-flow's
+ * controlled-mode re-sync from a changed `nodes` prop resets the drag's
+ * reference frame mid-gesture) — context lets highlight state change
+ * without ever touching node/edge identity.
+ */
+export interface HighlightState {
+  highlightedTables: Set<string> | null;
+  highlightedEdgeIds: Set<string> | null;
+  onFieldClick: (tableName: string, fieldName: string) => void;
+}
+
+export const HighlightContext = createContext<HighlightState>({
+  highlightedTables: null,
+  highlightedEdgeIds: null,
+  onFieldClick: () => {},
+});
 
 function selfLoopPath(sourceX: number, sourceY: number, targetX: number, targetY: number): string {
   return `M ${sourceX} ${sourceY} C ${sourceX + SELF_LOOP_OFFSET} ${sourceY}, ${targetX + SELF_LOOP_OFFSET} ${targetY}, ${targetX} ${targetY}`;
 }
 
-function CardinalityMarker({ label, x, y }: { label: Cardinality; x: number; y: number }) {
+function CardinalityMarker({
+  label,
+  x,
+  y,
+  dimmed,
+}: {
+  label: Cardinality;
+  x: number;
+  y: number;
+  dimmed: boolean;
+}) {
   return (
     <div
       style={{
         position: "absolute",
         transform: `translate(-50%, -50%) translate(${x}px, ${y}px)`,
         pointerEvents: "none",
+        opacity: dimmed ? 0.2 : 1,
       }}
       className="rounded border border-black/10 bg-background px-1 text-[10px] font-semibold text-zinc-600 dark:border-white/10 dark:text-zinc-300"
     >
@@ -35,9 +73,13 @@ export function RelationshipEdge({
   style,
   data,
 }: EdgeProps) {
+  const { highlightedTables, highlightedEdgeIds } = useContext(HighlightContext);
   const sourceCardinality = (data?.sourceCardinality as Cardinality | undefined) ?? "*";
   const targetCardinality = (data?.targetCardinality as Cardinality | undefined) ?? "*";
   const selfReferencing = Boolean(data?.selfReferencing);
+  const relationshipType = (data?.relationshipType as RelationshipType | undefined) ?? "one-to-many";
+  const isHighlighted = highlightedEdgeIds?.has(id) ?? false;
+  const isDimmed = highlightedTables !== null && !isHighlighted;
 
   const [path] = selfReferencing
     ? [selfLoopPath(sourceX, sourceY, targetX, targetY)]
@@ -48,19 +90,28 @@ export function RelationshipEdge({
     : (sourceX + targetX) / 2;
   const midY = (sourceY + targetY) / 2;
 
+  const edgeStyle = {
+    ...style,
+    stroke: RELATIONSHIP_TYPE_COLORS[relationshipType],
+    strokeWidth: isHighlighted ? 2.5 : 1.5,
+    opacity: isDimmed ? 0.2 : 1,
+  };
+
   return (
     <>
-      <BaseEdge id={id} path={path} style={style} />
+      <BaseEdge id={id} path={path} style={edgeStyle} />
       <EdgeLabelRenderer>
         <CardinalityMarker
           label={sourceCardinality}
           x={selfReferencing ? sourceX + 16 : sourceX + (midX - sourceX) * 0.15}
           y={selfReferencing ? sourceY : sourceY + (midY - sourceY) * 0.15}
+          dimmed={isDimmed}
         />
         <CardinalityMarker
           label={targetCardinality}
           x={selfReferencing ? targetX + 16 : targetX + (midX - targetX) * 0.15}
           y={selfReferencing ? targetY : targetY + (midY - targetY) * 0.15}
+          dimmed={isDimmed}
         />
       </EdgeLabelRenderer>
     </>

--- a/frontend/src/components/SchemaDiagramEditor.test.tsx
+++ b/frontend/src/components/SchemaDiagramEditor.test.tsx
@@ -1,12 +1,20 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { SchemaDiagramEditor } from "./SchemaDiagramEditor";
+import { RELATIONSHIP_TYPE_COLORS } from "./RelationshipEdge";
 
 function renderEditor(content: string) {
   return render(
     <SchemaDiagramEditor content={content} onContentChange={vi.fn()} layout={{}} onLayoutChange={vi.fn()} />,
   );
 }
+
+function tableNode(name: string) {
+  return document.querySelector(`[data-testid="table-node-${name}"]`) as HTMLElement;
+}
+
+const RELATED_DBML =
+  "Table orders {\n  id integer [primary key]\n  customer_id integer\n}\n\nTable customers {\n  id integer [primary key]\n}\n\nTable unrelated {\n  id integer [primary key]\n}\n\nRef: orders.customer_id > customers.id\n";
 
 describe("SchemaDiagramEditor relationships", () => {
   it("gives every field row a source and target Handle so edges can anchor at field granularity", () => {
@@ -44,5 +52,53 @@ describe("SchemaDiagramEditor relationships", () => {
     );
     expect(document.querySelector('[data-testid="rf__node-orders"]')).not.toBeNull();
     expect(screen.queryByText(/Broken reference/)).not.toBeInTheDocument();
+  });
+});
+
+describe("SchemaDiagramEditor hover highlight and click-to-jump", () => {
+  it("hovering a table highlights its connected table and dims unrelated tables", () => {
+    renderEditor(RELATED_DBML);
+    fireEvent.mouseEnter(tableNode("orders"));
+
+    expect(tableNode("customers").style.opacity).not.toBe("0.4");
+    expect(tableNode("unrelated").style.opacity).toBe("0.4");
+  });
+
+  it("unhovering clears the highlight/dim state", () => {
+    renderEditor(RELATED_DBML);
+    fireEvent.mouseEnter(tableNode("orders"));
+    fireEvent.mouseLeave(tableNode("orders"));
+
+    expect(tableNode("unrelated").style.opacity).not.toBe("0.4");
+    expect(tableNode("customers").style.opacity).not.toBe("0.4");
+  });
+
+  it("clicking a foreign-key field highlights the referenced table", () => {
+    renderEditor(RELATED_DBML);
+    fireEvent.click(within(tableNode("orders")).getByText("customer_id"));
+
+    expect(tableNode("customers").style.border).toContain("rgb(37, 99, 235)");
+  });
+
+  it("clicking a non-FK field does nothing", () => {
+    renderEditor(RELATED_DBML);
+    fireEvent.click(within(tableNode("orders")).getByText("id"));
+
+    expect(tableNode("customers").style.border).not.toContain("rgb(37, 99, 235)");
+    expect(tableNode("orders").style.border).not.toContain("rgb(37, 99, 235)");
+  });
+
+  // Actually starting a drag goes through react-flow's d3-drag integration,
+  // which needs real browser event/window plumbing jsdom doesn't provide
+  // (dispatching so much as a mousedown on a node crashes d3-drag's nodrag
+  // helper in jsdom regardless of this component's own code). That's
+  // covered for real in e2e/relationships.spec.ts instead.
+});
+
+describe("relationship type colors", () => {
+  it("assigns a distinct color to each relationship type", () => {
+    const colors = Object.values(RELATIONSHIP_TYPE_COLORS);
+    expect(colors).toHaveLength(3);
+    expect(new Set(colors).size).toBe(3);
   });
 });

--- a/frontend/src/components/SchemaDiagramEditor.tsx
+++ b/frontend/src/components/SchemaDiagramEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useContext, useMemo, useRef, useState } from "react";
 import {
   applyNodeChanges,
   Background,
@@ -10,16 +10,25 @@ import {
   NodeChange,
   NodeProps,
   NodeTypes,
+  Panel,
   Position,
   ReactFlow,
   ReactFlowProvider,
+  useReactFlow,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { Parser } from "@dbml/core";
 import { mergeLayout } from "@/lib/layout";
-import { buildRelationshipEdges, RelationshipEdge as RelationshipEdgeData } from "@/lib/relationships";
+import {
+  buildRelationshipEdges,
+  classifyRelationshipType,
+  connectionsForTable,
+  edgesForField,
+  RelationshipEdge as RelationshipEdgeData,
+  RelationshipType,
+} from "@/lib/relationships";
 import { Position as LayoutPosition } from "@/lib/types";
-import { RelationshipEdge } from "./RelationshipEdge";
+import { RelationshipEdge, RELATIONSHIP_TYPE_COLORS, HighlightContext } from "./RelationshipEdge";
 
 interface TableNodeData extends Record<string, unknown> {
   tableName: string;
@@ -27,12 +36,23 @@ interface TableNodeData extends Record<string, unknown> {
 }
 
 function TableNode({ data }: NodeProps<Node<TableNodeData>>) {
+  const { highlightedTables, onFieldClick } = useContext(HighlightContext);
+  const isHighlighted = highlightedTables?.has(data.tableName) ?? false;
+  const isDimmed = highlightedTables !== null && !isHighlighted;
+
   return (
     <div
+      data-testid={`table-node-${data.tableName}`}
       style={{
-        border: "1px solid rgba(0,0,0,0.1)",
+        // A constant-width border with only the color changing (rather than
+        // 1px <-> 2px) keeps the node's box dimensions fixed regardless of
+        // highlight state — flipping border-width mid-gesture was observed
+        // to abort an in-progress react-flow drag (likely a ResizeObserver
+        // remeasure resetting the drag's reference frame).
+        border: `2px solid ${isHighlighted ? "#2563eb" : "rgba(0,0,0,0.1)"}`,
         borderRadius: 8,
         width: 220,
+        opacity: isDimmed ? 0.4 : 1,
       }}
       className="bg-background text-left"
     >
@@ -41,7 +61,12 @@ function TableNode({ data }: NodeProps<Node<TableNodeData>>) {
       </div>
       <div className="px-2 py-1">
         {data.fields.map((field) => (
-          <div key={field.name} className="relative text-xs">
+          <div
+            key={field.name}
+            data-testid={`field-${data.tableName}-${field.name}`}
+            onClick={() => onFieldClick(data.tableName, field.name)}
+            className="relative cursor-pointer text-xs hover:bg-black/5 dark:hover:bg-white/5"
+          >
             <Handle
               type="target"
               position={Position.Left}
@@ -64,6 +89,122 @@ function TableNode({ data }: NodeProps<Node<TableNodeData>>) {
 
 const nodeTypes: NodeTypes = { tableNode: TableNode };
 const edgeTypes = { relationship: RelationshipEdge };
+
+const LEGEND_LABELS: Record<RelationshipType, string> = {
+  "one-to-one": "One-to-one",
+  "one-to-many": "One-to-many",
+  "many-to-many": "Many-to-many",
+};
+
+function RelationshipLegend() {
+  return (
+    <Panel
+      position="bottom-left"
+      className="flex flex-col gap-1 rounded-md border border-black/10 bg-background/90 p-2 text-xs dark:border-white/10"
+    >
+      {(Object.keys(LEGEND_LABELS) as RelationshipType[]).map((type) => (
+        <div key={type} className="flex items-center gap-1.5">
+          <span
+            className="inline-block h-0.5 w-4"
+            style={{ backgroundColor: RELATIONSHIP_TYPE_COLORS[type] }}
+          />
+          <span className="text-zinc-600 dark:text-zinc-300">{LEGEND_LABELS[type]}</span>
+        </div>
+      ))}
+    </Panel>
+  );
+}
+
+function FlowCanvas({
+  nodes,
+  edges,
+  onNodesChange,
+}: {
+  nodes: Node[];
+  edges: RelationshipEdgeData[];
+  onNodesChange: (changes: NodeChange[]) => void;
+}) {
+  const { setCenter, getNode } = useReactFlow();
+  const [hoveredTable, setHoveredTable] = useState<string | null>(null);
+  const [jumpTables, setJumpTables] = useState<Set<string> | null>(null);
+  const jumpTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const hoverConnections = hoveredTable ? connectionsForTable(hoveredTable, edges) : null;
+  const highlightedTables = hoverConnections
+    ? new Set([hoveredTable as string, ...hoverConnections.tableNames])
+    : jumpTables;
+  const highlightedEdgeIds = hoverConnections?.edgeIds ?? null;
+
+  function handleFieldClick(tableName: string, fieldName: string) {
+    const targets = edgesForField(tableName, fieldName, edges);
+    if (targets.length === 0) {
+      return;
+    }
+    const destinations = new Set<string>();
+    for (const edge of targets) {
+      destinations.add(edge.source === tableName ? edge.target : edge.source);
+    }
+    const firstDestination = getNode([...destinations][0]);
+    if (firstDestination) {
+      setCenter(firstDestination.position.x + 110, firstDestination.position.y + 60, {
+        zoom: 1,
+        duration: 400,
+      });
+    }
+    destinations.add(tableName);
+    setJumpTables(destinations);
+    if (jumpTimeoutRef.current) {
+      clearTimeout(jumpTimeoutRef.current);
+    }
+    jumpTimeoutRef.current = setTimeout(() => setJumpTables(null), 1500);
+  }
+
+  // flowEdges only carries data that's stable regardless of hover/click
+  // state (cardinalities, type, self-loop), so it — like `nodes` — never
+  // changes identity on hover. Highlight/dim state flows through
+  // HighlightContext instead of node/edge `data`, deliberately: see the
+  // comment on HighlightContext for why (rebuilding nodes/edges on every
+  // hover was observed to abort an in-progress drag).
+  const flowEdges = useMemo(
+    () =>
+      edges
+        .filter((edge) => !edge.dangling)
+        .map((edge) => ({
+          id: edge.id,
+          type: "relationship",
+          source: edge.source,
+          sourceHandle: edge.sourceHandle,
+          target: edge.target,
+          targetHandle: edge.targetHandle,
+          data: {
+            sourceCardinality: edge.sourceCardinality,
+            targetCardinality: edge.targetCardinality,
+            selfReferencing: edge.selfReferencing,
+            relationshipType: classifyRelationshipType(edge),
+          },
+        })),
+    [edges],
+  );
+
+  return (
+    <HighlightContext.Provider value={{ highlightedTables, highlightedEdgeIds, onFieldClick: handleFieldClick }}>
+      <ReactFlow
+        nodes={nodes}
+        edges={flowEdges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        onNodesChange={onNodesChange}
+        onNodeMouseEnter={(_, node) => setHoveredTable(node.id)}
+        onNodeMouseLeave={() => setHoveredTable(null)}
+        fitView
+      >
+        <Background />
+        <Controls />
+        <RelationshipLegend />
+      </ReactFlow>
+    </HighlightContext.Provider>
+  );
+}
 
 function tablesToNodes(
   dbml: string,
@@ -127,21 +268,6 @@ export function SchemaDiagramEditor({
   );
 
   const danglingEdges = edges.filter((edge) => edge.dangling);
-  const flowEdges = edges
-    .filter((edge) => !edge.dangling)
-    .map((edge) => ({
-      id: edge.id,
-      type: "relationship",
-      source: edge.source,
-      sourceHandle: edge.sourceHandle,
-      target: edge.target,
-      targetHandle: edge.targetHandle,
-      data: {
-        sourceCardinality: edge.sourceCardinality,
-        targetCardinality: edge.targetCardinality,
-        selfReferencing: edge.selfReferencing,
-      },
-    }));
 
   function handleNodesChange(changes: NodeChange[]) {
     if (!changes.some((change) => change.type === "position")) {
@@ -179,17 +305,7 @@ export function SchemaDiagramEditor({
             )}
             <div className="relative flex-1">
               <ReactFlowProvider>
-                <ReactFlow
-                  nodes={nodes}
-                  edges={flowEdges}
-                  nodeTypes={nodeTypes}
-                  edgeTypes={edgeTypes}
-                  onNodesChange={handleNodesChange}
-                  fitView
-                >
-                  <Background />
-                  <Controls />
-                </ReactFlow>
+                <FlowCanvas nodes={nodes} edges={edges} onNodesChange={handleNodesChange} />
               </ReactFlowProvider>
             </div>
           </>

--- a/frontend/src/lib/relationships.test.ts
+++ b/frontend/src/lib/relationships.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { buildRelationshipEdges, RelationshipRef, RelationshipTable } from "./relationships";
+import {
+  buildRelationshipEdges,
+  classifyRelationshipType,
+  connectionsForTable,
+  edgesForField,
+  RelationshipRef,
+  RelationshipTable,
+} from "./relationships";
 
 const orders: RelationshipTable = {
   name: "orders",
@@ -104,5 +111,82 @@ describe("buildRelationshipEdges", () => {
     );
     expect(edges).toHaveLength(2);
     expect(new Set(edges.map((e) => e.id)).size).toBe(2);
+  });
+});
+
+describe("classifyRelationshipType", () => {
+  it("classifies 1/* as one-to-many", () => {
+    expect(classifyRelationshipType({ sourceCardinality: "*", targetCardinality: "1" })).toBe(
+      "one-to-many",
+    );
+    expect(classifyRelationshipType({ sourceCardinality: "1", targetCardinality: "*" })).toBe(
+      "one-to-many",
+    );
+  });
+
+  it("classifies 1/1 as one-to-one", () => {
+    expect(classifyRelationshipType({ sourceCardinality: "1", targetCardinality: "1" })).toBe(
+      "one-to-one",
+    );
+  });
+
+  it("classifies */* as many-to-many", () => {
+    expect(classifyRelationshipType({ sourceCardinality: "*", targetCardinality: "*" })).toBe(
+      "many-to-many",
+    );
+  });
+});
+
+describe("connectionsForTable", () => {
+  const invoices: RelationshipTable = { name: "invoices", fields: [{ name: "id" }, { name: "customer_id" }] };
+  const edges = buildRelationshipEdges(
+    [orders, customers, invoices],
+    [
+      ref("orders", "customer_id", "*", "customers", "id", "1"),
+      ref("invoices", "customer_id", "*", "customers", "id", "1"),
+    ],
+  );
+
+  it("returns exactly the tables reachable via edges touching the given table, not transitively", () => {
+    const { tableNames } = connectionsForTable("customers", edges);
+    expect(tableNames).toEqual(new Set(["orders", "invoices"]));
+
+    const { tableNames: ordersConnections } = connectionsForTable("orders", edges);
+    expect(ordersConnections).toEqual(new Set(["customers"]));
+    expect(ordersConnections.has("invoices")).toBe(false);
+  });
+
+  it("returns an empty set for a table with no edges", () => {
+    const { tableNames, edgeIds } = connectionsForTable("unrelated_table", edges);
+    expect(tableNames.size).toBe(0);
+    expect(edgeIds.size).toBe(0);
+  });
+});
+
+describe("edgesForField", () => {
+  it("returns all Refs a field participates in, not just the first", () => {
+    const customersWithBilling: RelationshipTable = {
+      name: "customers",
+      fields: [{ name: "id" }, { name: "billing_id" }],
+    };
+    const billing: RelationshipTable = { name: "billing", fields: [{ name: "id" }] };
+    const edges = buildRelationshipEdges(
+      [orders, customersWithBilling, billing],
+      [
+        ref("orders", "customer_id", "*", "customers", "id", "1"),
+        ref("customers", "id", "1", "billing", "id", "1"),
+      ],
+    );
+
+    const targets = edgesForField("customers", "id", edges);
+    expect(targets).toHaveLength(2);
+  });
+
+  it("returns an empty array for a field with no Refs", () => {
+    const edges = buildRelationshipEdges(
+      [orders, customers],
+      [ref("orders", "customer_id", "*", "customers", "id", "1")],
+    );
+    expect(edgesForField("orders", "id", edges)).toEqual([]);
   });
 });

--- a/frontend/src/lib/relationships.ts
+++ b/frontend/src/lib/relationships.ts
@@ -32,6 +32,63 @@ function cardinalityOf(relation: string): Cardinality {
   return relation === "1" ? "1" : "*";
 }
 
+export type RelationshipType = "one-to-one" | "one-to-many" | "many-to-many";
+
+export function classifyRelationshipType(
+  edge: Pick<RelationshipEdge, "sourceCardinality" | "targetCardinality">,
+): RelationshipType {
+  if (edge.sourceCardinality === "1" && edge.targetCardinality === "1") {
+    return "one-to-one";
+  }
+  if (edge.sourceCardinality === "*" && edge.targetCardinality === "*") {
+    return "many-to-many";
+  }
+  return "one-to-many";
+}
+
+export interface TableConnections {
+  tableNames: Set<string>;
+  edgeIds: Set<string>;
+}
+
+/**
+ * Tables/edges directly connected to `tableName` — one hop only, not
+ * transitive, for the hover-highlight behaviour.
+ */
+export function connectionsForTable(tableName: string, edges: RelationshipEdge[]): TableConnections {
+  const tableNames = new Set<string>();
+  const edgeIds = new Set<string>();
+  for (const edge of edges) {
+    if (edge.dangling) continue;
+    if (edge.source === tableName) {
+      tableNames.add(edge.target);
+      edgeIds.add(edge.id);
+    } else if (edge.target === tableName) {
+      tableNames.add(edge.source);
+      edgeIds.add(edge.id);
+    }
+  }
+  return { tableNames, edgeIds };
+}
+
+/**
+ * All Refs a given field participates in (as either endpoint) — a field can
+ * be part of more than one Ref, and click-to-jump must resolve all of them
+ * rather than picking one arbitrarily.
+ */
+export function edgesForField(
+  tableName: string,
+  fieldName: string,
+  edges: RelationshipEdge[],
+): RelationshipEdge[] {
+  return edges.filter(
+    (edge) =>
+      !edge.dangling &&
+      ((edge.source === tableName && edge.sourceHandle === fieldName) ||
+        (edge.target === tableName && edge.targetHandle === fieldName)),
+  );
+}
+
 function describeMissing(endpoint: RelationshipRefEndpoint, table: RelationshipTable | undefined): string | null {
   const fieldName = endpoint.fieldNames[0];
   if (!table) {


### PR DESCRIPTION
## Summary
- `frontend/src/lib/relationships.ts`: adds `classifyRelationshipType`, `connectionsForTable` (one-hop table/edge lookup for hover), and `edgesForField` (all Refs a field participates in, for click-to-jump) — pure, no react-flow imports
- Hovering a table (`onNodeMouseEnter`/`onNodeMouseLeave` on `<ReactFlow>`) highlights its connected table(s)/edge(s) and dims everything else
- Clicking a foreign-key field pans/zooms (`useReactFlow().setCenter`) to the referenced table and briefly highlights all its targets (not just the first, if a field has multiple Refs); clicking a non-FK field is a no-op
- Edges are colored by relationship type with a `<Panel>` legend so the color mapping is discoverable, not memorized

## A real bug found and fixed along the way
Baking `isHighlighted`/`isDimmed` into react-flow's `nodes`/`edges` `data` (rebuilding those arrays fresh on every hover) **silently aborted an in-progress table drag** — confirmed against a real browser (not assumed): dragging while hovering the same node moved it by exactly zero pixels, no error thrown. This reproduced even hovering via react-flow's own official `onNodeMouseEnter` prop, and even with `nodes` array identity unchanged content-wise — the trigger was rebuilding `nodes`/`edges` object identity at all while "controlled" (external `nodes`+`onNodesChange`), which apparently makes react-flow re-sync mid-gesture and reset the drag's reference frame.

Fix: `HighlightContext` (new, in `RelationshipEdge.tsx`) carries `highlightedTables`/`highlightedEdgeIds`/`onFieldClick` down to `TableNode`/`RelationshipEdge` via React context instead of node/edge `data`. `nodes` and the edge list now stay perfectly stable across hover changes — only the context value changes, so react-flow never sees a new `nodes` prop from a hover alone. Regression-tested directly (a scratch Playwright spec drag-while-hovering, deleted after confirming the fix) before folding the real coverage into `e2e/relationships.spec.ts`.

## Test plan
- [x] `npx eslint`, `next typegen && npx tsc --noEmit`, `next build` — all clean
- [x] `npx vitest run` — 115/115 passing, including 7 new `relationships.test.ts` cases and new `SchemaDiagramEditor.test.tsx` hover/click coverage
- [x] Full Playwright suite (21 specs, including 6 new relationship-interaction specs: hover highlight/dim, click-to-jump pan+highlight, non-FK click no-op, distinct edge colors + visible legend, and drag-still-works-after-hover) against a real backend+Postgres on an isolated Docker network, `CI=true` — **21/21 passing, run twice** given the severity of the drag bug this PR fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w