### PR TITLE
Add GHCR release workflow for main-branch pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: frontend
+            context: ./frontend
+            image: ghcr.io/naphatnu/omnidiagram-frontend
+          - name: backend
+            context: ./backend
+            image: ghcr.io/naphatnu/omnidiagram-backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml`, triggered only on `push` to `main`
- Matrix job builds `frontend/Dockerfile` and `backend/Dockerfile`, logs into `ghcr.io` with the built-in `GITHUB_TOKEN`, and pushes `ghcr.io/naphatnu/omnidiagram-frontend` / `-backend` tagged `latest` and the commit SHA
- Uses `type=gha` cache (scoped per image) so the Maven build isn't slow on every push

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses
- [ ] After merge to `main`: `gh run list --workflow=release.yml` shows a successful run
- [ ] Flip both GHCR packages to public in package settings (per issue notes)
- [ ] `docker logout ghcr.io && docker pull ghcr.io/naphatnu/omnidiagram-frontend:latest` succeeds anonymously
- [ ] `docker pull ghcr.io/naphatnu/omnidiagram-backend:latest` succeeds anonymously
- [ ] Confirm the workflow does not fire on this PR (by design — `pull_request` isn't a trigger)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w