### PR TITLE
Fix GHCR release workflow: set up buildx before build-push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: docker/setup-buildx-action@v3
+
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
## Summary
- The first run of `release.yml` (from #50) failed: `ERROR: failed to build: Cache export is not supported for the docker driver.`
- The default `docker` buildx driver doesn't support the `type=gha` cache backend used in `cache-from`/`cache-to`
- Adds `docker/setup-buildx-action@v3`, which switches to the `docker-container` driver, before `docker/build-push-action`

## Test plan
- [x] YAML parses
- [ ] After merge: `gh run list --workflow=release.yml` shows a successful run
- [ ] `docker pull ghcr.io/naphatnu/omnidiagram-frontend:latest` / `-backend:latest` succeed anonymously

Part of #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w