### PR TITLE
Add incident log for #19's GHCR pipeline failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # Working preferences
 
 - Before starting any coding task in this repo, invoke the `andrej-karpathy-skills:karpathy-guidelines` skill.
+- Before touching CI/CD workflows, Docker builds, or deploy tooling, read `docs/incidents.md` — it logs failures that weren't obvious from reading the code, with root cause and fix, so the same class of bug isn't re-debugged from scratch. Add a new entry there (don't just fix silently) whenever a similar non-obvious failure turns up.
 
 ## Reporting
 

--- a/docs/incidents.md
+++ b/docs/incidents.md
@@ -1,0 +1,45 @@
+# Incident log
+
+A running record of bugs/failures that weren't obvious from reading the code — each one cost real debugging time once, so read this before repeating the same class of work. Rationale docs for planned decisions live in `docs/adr/`; this file is postmortems for things that broke in practice.
+
+Format per entry: **Symptom**, **Root cause**, **Why it wasn't caught earlier**, **Fix**.
+
+## 2026-08-17 — GHCR release workflow: two build failures on first real run (#19)
+
+Landed in three PRs: #50 (workflow), #51 (fix 1), #52 (fix 2). Both bugs only surfaced because #19 was the first issue to actually run `docker build` against the images in CI — nothing before it did.
+
+### Failure 1 — buildx cache export rejected by the default driver
+
+**Symptom:** `.github/workflows/release.yml`'s first run failed immediately in `docker/build-push-action`:
+```
+ERROR: failed to build: Cache export is not supported for the docker driver.
+Switch to a different driver, or turn on the containerd image store, and try again.
+```
+
+**Root cause:** `docker/build-push-action` was configured with `cache-from: type=gha` / `cache-to: type=gha,mode=max` (per #19's spec, to keep the Maven build fast). GitHub-hosted runners' preinstalled Docker uses the `docker` buildx driver by default, which doesn't support the `gha` cache exporter — only the `docker-container` driver does.
+
+**Why it wasn't caught earlier:** #19's issue body specified `cache-from`/`cache-to: type=gha` but didn't mention `docker/setup-buildx-action`, which is what switches the driver. This is a gap in the issue spec, not a regression from an earlier merged issue — no prior issue touched Docker image builds at all (#3, the CI workflow, only runs `npm`/`mvn` — it never builds a Docker image).
+
+**Fix:** add `docker/setup-buildx-action@v3` before `docker/build-push-action` in every job that uses `cache-from`/`cache-to: type=gha`.
+
+### Failure 2 — `frontend/public/` missing on a fresh checkout
+
+**Symptom:** after fixing the driver, the frontend leg failed:
+```
+ERROR: failed to build: failed to solve: failed to compute cache key:
+failed to calculate checksum of ref ...: "/app/public": not found
+```
+
+**Root cause:** `frontend/Dockerfile`'s runtime stage does `COPY --from=build /app/public ./public`. `frontend/public/` exists on disk in every local working tree but has been **empty** since the repo's original scaffold commit (`64e6db6`, "Scaffold Next.js frontend, Spring Boot backend, and docker-compose topology" — this predates the tracked issue list; Next.js's App Router convention put `favicon.ico` under `src/app/` instead, so nothing ever landed in `public/`). Git does not track empty directories, so `frontend/public/` was **never actually committed** — a fresh `git clone`/CI checkout (what `actions/checkout` does) never had it, even though every local working copy that ran `npm run build`/`next dev` at least once did (Next.js may create files there, or the directory simply persisted from the original `create-next-app` scaffold before anything was deleted from it).
+
+**Why it wasn't caught earlier:** no issue before #19 ever built the frontend Docker image from a clean checkout. #3 (CI workflow) runs `npm run build`, which doesn't fail on a missing `public/` — Next.js tolerates that fine. Only `docker build` from a truly fresh clone exercises the `COPY` that assumes the directory exists.
+
+**Fix:** `frontend/public/.gitkeep` — tracks the (still-empty) directory in git. No Dockerfile change needed.
+
+### Process note
+
+PR #50's body contained "Closes #19", so the issue auto-closed the moment #50 merged — **before** #51/#52 (the actual fixes) landed and the pipeline worked end-to-end. Had to add a follow-up comment instead of `gh issue close` once truly verified. **Only put "Closes #N" on the PR you're confident is the final one for that issue** when a fix might need follow-up PRs.
+
+### General lesson
+
+Any future workflow/issue that runs `docker build` for the first time against a directory or cache backend that no prior issue has exercised should expect at least one failure mode invisible from reading the Dockerfile/workflow alone — plan to iterate against a real run, not just a YAML lint.


### PR DESCRIPTION
## Summary
- New `docs/incidents.md`: postmortem log of the two build failures hit while landing #19 (buildx cache-driver rejection; `frontend/public/` never tracked by git because it was empty) — symptom, root cause, why it wasn't caught earlier, and fix for each
- `CLAUDE.md`: points at `docs/incidents.md` before any CI/CD, Docker build, or deploy work, and asks for a new entry whenever a similar non-obvious failure turns up

Docs-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w