### PR TITLE
Add self-hosted runner deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy
+
+# Runs only after the Release workflow (image build/push) finishes successfully
+# on main. Never triggers on pull_request/pull_request_target — this job runs
+# on a self-hosted runner (kla-server), and a fork PR must never reach it.
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  deploy:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: self-hosted
+    steps:
+      # clean: false — the compose root doubles as the runner's checkout
+      # directory and holds the gitignored .env and the Postgres bind mount
+      # (./data/postgres). The default `git clean -ffdx` would delete both.
+      - uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy
+        run: ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Pulls the latest images and restarts the compose stack. Run from the
+# compose root (where docker-compose.yml and the server's .env live) —
+# either by hand or via .github/workflows/deploy.yml.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+docker compose pull
+docker compose up -d
+
+echo "Waiting for backend health check..."
+for i in $(seq 1 30); do
+  if docker compose exec -T backend wget -qO- http://localhost:8080/actuator/health > /dev/null 2>&1; then
+    echo "Backend is healthy"
+    docker image prune -f
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "Backend failed health check after 60s" >&2
+docker compose logs backend
+exit 1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -72,5 +72,15 @@ MCP_API_KEY=
 ## CI/CD
 
 - Pull requests run on GitHub-hosted runners: lint, typecheck, Vitest, Playwright, and `mvn verify` (Testcontainers).
-- Pushes to `main` build images, push them to GHCR, then deploy via a self-hosted runner on `kla-server`.
-- The deploy workflow triggers **only** on `push` to `main`, never on `pull_request` — a fork PR must never execute on the self-hosted runner.
+- Pushes to `main` build images and push them to GHCR (`release.yml`), then `deploy.yml` runs on a self-hosted runner on `kla-server`.
+- `deploy.yml` triggers on `workflow_run` after `release.yml` completes on `main` (not on `push` directly) so the deploy never races a build still pushing images. It never triggers on `pull_request` — a fork PR must never execute on the self-hosted runner.
+- `deploy.sh` (repo root) does the actual work: `docker compose pull`, `docker compose up -d`, poll the backend's `/actuator/health` (inside the compose network, via `docker compose exec`) for up to 60s, fail loudly if it never comes up, then `docker image prune -f`. It can also be run by hand from the compose root.
+
+### Self-hosted runner setup (manual, once)
+
+Public repos must not run untrusted code on a self-hosted runner, so the whole design routes around that: `deploy.yml` only ever fires via `workflow_run` off `release.yml`, which itself only runs on `push` to `main`, and `main` requires review. Also enable **require approval for workflow runs from outside collaborators** in repo Settings → Actions.
+
+1. Settings → Actions → Runners → add a runner, install it on `kla-server` as a service running under a **dedicated, non-root user** with Docker access, in a work directory outside the other stacks' directories (`sdvd-*`, `retirement-planner-app`, `cloudflare-tunnel`).
+2. Before the first deploy, create the `.env` file in that runner's checkout directory (it becomes the compose root — see [Secrets](#secrets)). It's gitignored and never comes from CI.
+3. `docker login ghcr.io` isn't needed on the host itself — `deploy.yml` logs in with `GITHUB_TOKEN` before calling `deploy.sh`.
+4. The `actions/checkout` step in `deploy.yml` runs with `clean: false`: the checkout directory is reused as the compose root across runs, and the default `git clean -ffdx` would otherwise delete the untracked `.env` and the `./data/postgres` bind mount (the live database) on every deploy.


### PR DESCRIPTION
## Summary
- `.github/workflows/deploy.yml` — new workflow on `runs-on: self-hosted`, triggered by `workflow_run` after `release.yml` completes successfully on `main` (never `push`/`pull_request` directly), so a deploy never races an in-flight image build and a fork PR can never reach the runner.
- `deploy.sh` (repo root) — `docker compose pull && docker compose up -d`, then polls the backend's `/actuator/health` for up to 60s via `docker compose exec` (checked directly against the backend container, not through Caddy — see note below), fails loudly with `docker compose logs backend` and exit 1 if it never comes up, then `docker image prune -f`. Runs standalone by hand too.
- `docs/deployment.md` — documents the trigger chain and adds a "Self-hosted runner setup" section with the manual one-time steps.

## Note: health-check path deviates from the issue's literal wording
The issue said to poll `/api/actuator/health`. I verified locally that Caddy's `handle /api/* { reverse_proxy backend:8080 }` does **not** strip the `/api` prefix, and the backend's actuator endpoint is mapped at `/actuator/health` (root), not under `/api` — so a literal `curl localhost:8090/api/actuator/health` 404s (confirmed with a local `docker compose up`). `deploy.sh` instead checks the endpoint that actually exists, directly against the backend container via `docker compose exec`, matching the same endpoint CI already uses (`ci.yml`'s `curl http://localhost:8080/actuator/health`). This avoids depending on Caddy routing for a liveness check and sidesteps a would-be-permanent false-failure. Caddyfile wasn't in the issue's file list, so I left it untouched rather than adding a strip-prefix route for this.

## Also verified
- `actions/checkout` runs with `clean: false`, since the runner's checkout directory doubles as the compose root holding the gitignored `.env` and the Postgres bind mount (`./data/postgres`) — the default `git clean -ffdx` would delete both on every deploy.

## Test plan
- [x] `docker compose build` — both images build clean
- [x] `docker compose config` validates with a test `.env`
- [x] Ran `./deploy.sh` end to end against a local stack (real GHCR images): pull, recreate, health check passes, prune runs, exit 0
- [x] Re-ran `deploy.sh` idempotently — succeeds again, exit 0
- [x] Simulated a broken health check (wrong port) — fails loudly, dumps backend logs, exits 1
- [x] Confirmed `localhost:8090/api/actuator/health` 404s through Caddy (documents why the health check bypasses it) while `docker compose exec backend wget -qO- localhost:8080/actuator/health` returns `{"status":"UP"}`
- [x] Cleaned up all local test containers/volumes/`.env`/`data/`
- [ ] Runner-side acceptance criteria (`gh run list --workflow=deploy.yml`, live deploy to `kla-server`) can't be verified from this environment — no self-hosted runner is registered yet; needs the manual one-time runner setup documented in `docs/deployment.md` before this workflow can actually fire.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w