### PR TITLE
Add UI to rename a diagram's title

### DIFF
--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -20,3 +20,41 @@ test("create a GenericDiagram, see it listed, then delete it", async ({ page }) 
   await page.reload();
   await expect(page.locator(`a[href="/share/${token}"]`)).not.toBeVisible();
 });
+
+test("rename a diagram from the dashboard and see it persist after reload", async ({ page }) => {
+  await page.goto("/dashboard");
+
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "GenericDiagram" }).click();
+  await expect(page).toHaveURL(/\/share\/[^/]+$/);
+  const token = page.url().split("/share/")[1];
+
+  await page.goto("/dashboard");
+  const row = page.locator(`[data-testid="diagram-row-${token}"]`);
+  await row.getByText("Rename").click();
+  const input = row.locator("input");
+  await input.fill("Renamed from dashboard");
+  await input.press("Enter");
+
+  await expect(row.getByText("Renamed from dashboard")).toBeVisible();
+  await page.reload();
+  await expect(row.getByText("Renamed from dashboard")).toBeVisible();
+});
+
+test("renaming to a blank title falls back to Untitled diagram", async ({ page }) => {
+  await page.goto("/dashboard");
+
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "GenericDiagram" }).click();
+  await expect(page).toHaveURL(/\/share\/[^/]+$/);
+  const token = page.url().split("/share/")[1];
+
+  await page.goto("/dashboard");
+  const row = page.locator(`[data-testid="diagram-row-${token}"]`);
+  await row.getByText("Rename").click();
+  const input = row.locator("input");
+  await input.fill("   ");
+  await input.press("Enter");
+
+  await expect(row.getByText("Untitled diagram")).toBeVisible();
+});

--- a/frontend/e2e/editor.spec.ts
+++ b/frontend/e2e/editor.spec.ts
@@ -37,3 +37,26 @@ test("navigating away with unsaved changes warns first", async ({ page }) => {
   expect(dialogMessage).toContain("unsaved changes");
   await expect(page).toHaveURL(/\/share\/[^/]+$/);
 });
+
+test("renaming the title in the editor header requires Save, and persists after reload", async ({
+  page,
+}) => {
+  await page.goto("/dashboard");
+  await page.getByRole("button", { name: "New Diagram" }).click();
+  await page.getByRole("button", { name: "SchemaDiagram" }).click();
+  await expect(page).toHaveURL(/\/share\/[^/]+$/);
+
+  await page.getByRole("button", { name: "Rename" }).click();
+  const input = page.locator("input").first();
+  await input.fill("Renamed in editor");
+  await input.press("Tab");
+
+  // Committing the title marks the diagram dirty but does not save it yet.
+  await expect(page.getByText("Unsaved changes")).toBeVisible();
+
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(page.getByText("Saved")).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByText("Renamed in editor")).toBeVisible();
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -43,7 +43,7 @@ export default function Dashboard() {
         ) : (
           <div className="rounded-lg border border-black/10 dark:border-white/10">
             {diagrams.map((diagram) => (
-              <DiagramRow key={diagram.shareToken} diagram={diagram} onDeleted={load} />
+              <DiagramRow key={diagram.shareToken} diagram={diagram} onDeleted={load} onRenamed={load} />
             ))}
           </div>
         )}

--- a/frontend/src/app/share/[token]/page.tsx
+++ b/frontend/src/app/share/[token]/page.tsx
@@ -19,6 +19,8 @@ function Editor({ diagram }: { diagram: Diagram }) {
     <div className="flex flex-1 flex-col">
       <EditorHeader
         diagram={editor.diagram}
+        title={editor.title}
+        onTitleChange={editor.setTitle}
         content={editor.content}
         isDirty={editor.isDirty}
         isSaving={editor.isSaving}

--- a/frontend/src/components/DiagramRow.test.tsx
+++ b/frontend/src/components/DiagramRow.test.tsx
@@ -1,11 +1,12 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DiagramRow } from "./DiagramRow";
-import { deleteDiagram } from "@/lib/api";
+import { deleteDiagram, updateDiagram } from "@/lib/api";
 import { DiagramSummary } from "@/lib/types";
 
 vi.mock("@/lib/api", () => ({
   deleteDiagram: vi.fn(),
+  updateDiagram: vi.fn(),
 }));
 
 const diagram: DiagramSummary = {
@@ -17,10 +18,13 @@ const diagram: DiagramSummary = {
 
 describe("DiagramRow", () => {
   let onDeleted: ReturnType<typeof vi.fn>;
+  let onRenamed: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.mocked(deleteDiagram).mockReset();
+    vi.mocked(updateDiagram).mockReset();
     onDeleted = vi.fn();
+    onRenamed = vi.fn();
   });
 
   afterEach(() => {
@@ -30,7 +34,7 @@ describe("DiagramRow", () => {
   it("does not call deleteDiagram when the confirm dialog is dismissed", () => {
     vi.spyOn(window, "confirm").mockReturnValue(false);
 
-    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} />);
+    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} onRenamed={onRenamed} />);
     fireEvent.click(screen.getByText("Delete"));
 
     expect(deleteDiagram).not.toHaveBeenCalled();
@@ -41,7 +45,7 @@ describe("DiagramRow", () => {
     vi.spyOn(window, "confirm").mockReturnValue(true);
     vi.mocked(deleteDiagram).mockResolvedValue(undefined);
 
-    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} />);
+    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} onRenamed={onRenamed} />);
     fireEvent.click(screen.getByText("Delete"));
 
     expect(deleteDiagram).toHaveBeenCalledWith("abc");
@@ -52,7 +56,7 @@ describe("DiagramRow", () => {
     vi.spyOn(window, "confirm").mockReturnValue(true);
     vi.mocked(deleteDiagram).mockRejectedValue(new Error("boom"));
 
-    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} />);
+    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} onRenamed={onRenamed} />);
     fireEvent.click(screen.getByText("Delete"));
 
     await waitFor(() => expect(screen.getByText("Delete failed")).toBeInTheDocument());
@@ -69,12 +73,63 @@ describe("DiagramRow", () => {
       }),
     );
 
-    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} />);
+    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} onRenamed={onRenamed} />);
     fireEvent.click(screen.getByText("Delete"));
 
     expect(screen.getByText("Delete")).toBeDisabled();
 
     resolve();
     await waitFor(() => expect(onDeleted).toHaveBeenCalled());
+  });
+
+  it("renames via the Rename button, saving on blur", async () => {
+    vi.mocked(updateDiagram).mockResolvedValue({
+      ...diagram,
+      title: "Renamed",
+      content: "",
+      layout: {},
+    });
+
+    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} onRenamed={onRenamed} />);
+    fireEvent.click(screen.getByText("Rename"));
+
+    const input = screen.getByDisplayValue("Orders schema");
+    fireEvent.change(input, { target: { value: "Renamed" } });
+    fireEvent.blur(input);
+
+    expect(updateDiagram).toHaveBeenCalledWith("abc", { title: "Renamed" });
+    await waitFor(() => expect(onRenamed).toHaveBeenCalled());
+  });
+
+  it("falls back to 'Untitled diagram' when saved blank", async () => {
+    vi.mocked(updateDiagram).mockResolvedValue({
+      ...diagram,
+      title: "Untitled diagram",
+      content: "",
+      layout: {},
+    });
+
+    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} onRenamed={onRenamed} />);
+    fireEvent.click(screen.getByText("Rename"));
+
+    const input = screen.getByDisplayValue("Orders schema");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(updateDiagram).toHaveBeenCalledWith("abc", { title: "Untitled diagram" }),
+    );
+  });
+
+  it("cancels editing on Escape without saving", () => {
+    render(<DiagramRow diagram={diagram} onDeleted={onDeleted} onRenamed={onRenamed} />);
+    fireEvent.click(screen.getByText("Rename"));
+
+    const input = screen.getByDisplayValue("Orders schema");
+    fireEvent.change(input, { target: { value: "Something else" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(updateDiagram).not.toHaveBeenCalled();
+    expect(screen.getByText("Orders schema")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/DiagramRow.tsx
+++ b/frontend/src/components/DiagramRow.tsx
@@ -2,20 +2,28 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { deleteDiagram } from "@/lib/api";
+import { deleteDiagram, updateDiagram } from "@/lib/api";
 import { formatUpdatedAt } from "@/lib/format";
 import { DiagramSummary } from "@/lib/types";
 import { KindBadge } from "./KindBadge";
 
+const DEFAULT_TITLE = "Untitled diagram";
+
 export function DiagramRow({
   diagram,
   onDeleted,
+  onRenamed,
 }: {
   diagram: DiagramSummary;
   onDeleted: () => void;
+  onRenamed: () => void;
 }) {
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [title, setTitle] = useState(diagram.title);
+  const [renaming, setRenaming] = useState(false);
+  const [renameError, setRenameError] = useState(false);
 
   async function handleDelete() {
     if (!window.confirm(`Delete "${diagram.title}"? This can't be undone.`)) {
@@ -32,22 +40,84 @@ export function DiagramRow({
     }
   }
 
+  function startEditing() {
+    setTitle(diagram.title);
+    setRenameError(false);
+    setIsEditing(true);
+  }
+
+  function cancelEditing() {
+    setTitle(diagram.title);
+    setIsEditing(false);
+  }
+
+  async function commitRename() {
+    const nextTitle = title.trim() === "" ? DEFAULT_TITLE : title.trim();
+    if (nextTitle === diagram.title) {
+      setIsEditing(false);
+      return;
+    }
+    setRenaming(true);
+    setRenameError(false);
+    try {
+      await updateDiagram(diagram.shareToken, { title: nextTitle });
+      setIsEditing(false);
+      onRenamed();
+    } catch {
+      setRenameError(true);
+    } finally {
+      setRenaming(false);
+    }
+  }
+
   return (
-    <div className="flex items-center justify-between border-b border-black/5 px-4 py-3 last:border-0 dark:border-white/5">
-      <Link
-        href={`/share/${diagram.shareToken}`}
-        className="flex min-w-0 flex-1 items-center gap-3"
-      >
-        <span className="truncate text-sm font-medium">{diagram.title}</span>
-        <KindBadge kind={diagram.kind} />
-      </Link>
+    <div
+      data-testid={`diagram-row-${diagram.shareToken}`}
+      className="flex items-center justify-between border-b border-black/5 px-4 py-3 last:border-0 dark:border-white/5"
+    >
+      {isEditing ? (
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            onBlur={commitRename}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") e.currentTarget.blur();
+              if (e.key === "Escape") cancelEditing();
+            }}
+            disabled={renaming}
+            autoFocus
+            className="min-w-0 flex-1 rounded-md border border-black/10 bg-transparent px-2 py-1 text-sm font-medium outline-none dark:border-white/10"
+          />
+          <KindBadge kind={diagram.kind} />
+        </div>
+      ) : (
+        <Link
+          href={`/share/${diagram.shareToken}`}
+          className="flex min-w-0 flex-1 items-center gap-3"
+        >
+          <span className="truncate text-sm font-medium">{diagram.title}</span>
+          <KindBadge kind={diagram.kind} />
+        </Link>
+      )}
       <div className="flex shrink-0 items-center gap-4">
+        {renameError && (
+          <span className="text-xs text-red-600 dark:text-red-400">Rename failed</span>
+        )}
         {error && (
           <span className="text-xs text-red-600 dark:text-red-400">Delete failed</span>
         )}
         <span className="text-xs text-zinc-500 dark:text-zinc-400">
           {formatUpdatedAt(diagram.updatedAt)}
         </span>
+        {!isEditing && (
+          <button
+            onClick={startEditing}
+            className="text-xs font-medium hover:underline"
+          >
+            Rename
+          </button>
+        )}
         <button
           onClick={handleDelete}
           disabled={deleting}

--- a/frontend/src/components/EditorHeader.test.tsx
+++ b/frontend/src/components/EditorHeader.test.tsx
@@ -18,6 +18,8 @@ function renderHeader(overrides: Partial<Parameters<typeof EditorHeader>[0]> = {
   return render(
     <EditorHeader
       diagram={diagram}
+      title={diagram.title}
+      onTitleChange={vi.fn()}
       content={diagram.content}
       isDirty={false}
       isSaving={false}
@@ -77,5 +79,42 @@ describe("EditorHeader", () => {
     renderHeader();
     fireEvent.click(screen.getByText("Import"));
     expect(screen.getByPlaceholderText("Paste CREATE TABLE statements...")).toBeInTheDocument();
+  });
+
+  it("renames via the Rename button, committing on blur", () => {
+    const onTitleChange = vi.fn();
+    renderHeader({ onTitleChange });
+    fireEvent.click(screen.getByText("Rename"));
+
+    const input = screen.getByDisplayValue("Orders");
+    fireEvent.change(input, { target: { value: "Renamed" } });
+    fireEvent.blur(input);
+
+    expect(onTitleChange).toHaveBeenCalledWith("Renamed");
+  });
+
+  it("falls back to 'Untitled diagram' when committed blank", () => {
+    const onTitleChange = vi.fn();
+    renderHeader({ onTitleChange });
+    fireEvent.click(screen.getByText("Rename"));
+
+    const input = screen.getByDisplayValue("Orders");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.blur(input);
+
+    expect(onTitleChange).toHaveBeenCalledWith("Untitled diagram");
+  });
+
+  it("cancels editing on Escape without committing", () => {
+    const onTitleChange = vi.fn();
+    renderHeader({ onTitleChange });
+    fireEvent.click(screen.getByText("Rename"));
+
+    const input = screen.getByDisplayValue("Orders");
+    fireEvent.change(input, { target: { value: "Something else" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(onTitleChange).not.toHaveBeenCalled();
+    expect(screen.getByText("Orders")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/EditorHeader.tsx
+++ b/frontend/src/components/EditorHeader.tsx
@@ -7,8 +7,12 @@ import { ExportMenu } from "./ExportMenu";
 import { ImportDialog } from "./ImportDialog";
 import { KindBadge } from "./KindBadge";
 
+const DEFAULT_TITLE = "Untitled diagram";
+
 export function EditorHeader({
   diagram,
+  title,
+  onTitleChange,
   content,
   isDirty,
   isSaving,
@@ -20,6 +24,8 @@ export function EditorHeader({
   onImport,
 }: {
   diagram: Diagram;
+  title: string;
+  onTitleChange: (title: string) => void;
   content: string;
   isDirty: boolean;
   isSaving: boolean;
@@ -31,6 +37,25 @@ export function EditorHeader({
   onImport: (dbml: string) => void;
 }) {
   const [importOpen, setImportOpen] = useState(false);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(title);
+
+  function startEditingTitle() {
+    setTitleDraft(title);
+    setIsEditingTitle(true);
+  }
+
+  function commitTitle() {
+    const next = titleDraft.trim() === "" ? DEFAULT_TITLE : titleDraft.trim();
+    onTitleChange(next);
+    setIsEditingTitle(false);
+  }
+
+  function cancelEditingTitle() {
+    setTitleDraft(title);
+    setIsEditingTitle(false);
+  }
+
   return (
     <AppHeader
       onNavigateAway={(event) => {
@@ -39,7 +64,27 @@ export function EditorHeader({
         }
       }}
     >
-      <span className="text-sm font-medium">{diagram.title}</span>
+      {isEditingTitle ? (
+        <input
+          value={titleDraft}
+          onChange={(e) => setTitleDraft(e.target.value)}
+          onBlur={commitTitle}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") e.currentTarget.blur();
+            if (e.key === "Escape") cancelEditingTitle();
+          }}
+          autoFocus
+          className="rounded-md border border-black/10 bg-transparent px-2 py-1 text-sm font-medium outline-none dark:border-white/10"
+        />
+      ) : (
+        <span className="text-sm font-medium">{title}</span>
+      )}
+      <button
+        onClick={startEditingTitle}
+        className="text-xs font-medium hover:underline"
+      >
+        Rename
+      </button>
       <KindBadge kind={diagram.kind} />
       {error ? (
         <span className="text-xs text-red-600 dark:text-red-400">{error}</span>

--- a/frontend/src/hooks/useDiagramEditor.test.ts
+++ b/frontend/src/hooks/useDiagramEditor.test.ts
@@ -129,6 +129,37 @@ describe("useDiagramEditor", () => {
     expect(result.current.isDirty).toBe(false);
   });
 
+  it("marks dirty when the title changes", () => {
+    const { result } = renderHook(() => useDiagramEditor(initial));
+    act(() => result.current.setTitle("New title"));
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it("sends only the title when only the title changed", async () => {
+    vi.mocked(updateDiagram).mockResolvedValue({ ...initial, title: "New title" });
+    const { result } = renderHook(() => useDiagramEditor(initial));
+    act(() => result.current.setTitle("New title"));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(updateDiagram).toHaveBeenCalledWith("abc", { title: "New title" });
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it("falls back to 'Untitled diagram' when saved blank", async () => {
+    vi.mocked(updateDiagram).mockResolvedValue({ ...initial, title: "Untitled diagram" });
+    const { result } = renderHook(() => useDiagramEditor(initial));
+    act(() => result.current.setTitle("   "));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(updateDiagram).toHaveBeenCalledWith("abc", { title: "Untitled diagram" });
+  });
+
   it("applyDiagram replaces content and layout and clears dirty state", () => {
     const { result } = renderHook(() => useDiagramEditor(initial));
     act(() => result.current.setContent("changed"));

--- a/frontend/src/hooks/useDiagramEditor.ts
+++ b/frontend/src/hooks/useDiagramEditor.ts
@@ -5,30 +5,37 @@ import { ApiError, updateDiagram } from "@/lib/api";
 import { layoutsEqual } from "@/lib/layout";
 import { Diagram, DiagramPatch } from "@/lib/types";
 
+const DEFAULT_TITLE = "Untitled diagram";
+
 export function useDiagramEditor(initial: Diagram) {
   const [diagram, setDiagram] = useState(initial);
+  const [title, setTitle] = useState(initial.title);
   const [content, setContent] = useState(initial.content);
   const [layout, setLayout] = useState(initial.layout);
+  const [lastSavedTitle, setLastSavedTitle] = useState(initial.title);
   const [lastSavedContent, setLastSavedContent] = useState(initial.content);
   const [lastSavedLayout, setLastSavedLayout] = useState(initial.layout);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const savingRef = useRef(false);
 
+  const titleDirty = title !== lastSavedTitle;
   const contentDirty = content !== lastSavedContent;
   const layoutDirty = !layoutsEqual(layout, lastSavedLayout);
-  const isDirty = contentDirty || layoutDirty;
+  const isDirty = titleDirty || contentDirty || layoutDirty;
 
   const applyDiagram = useCallback((updated: Diagram) => {
+    setLastSavedTitle(updated.title);
     setLastSavedContent(updated.content);
     setLastSavedLayout(updated.layout);
     setDiagram(updated);
+    setTitle(updated.title);
     setContent(updated.content);
     setLayout(updated.layout);
   }, []);
 
   const save = useCallback(async () => {
-    if (savingRef.current || (!contentDirty && !layoutDirty)) {
+    if (savingRef.current || (!titleDirty && !contentDirty && !layoutDirty)) {
       return;
     }
     savingRef.current = true;
@@ -36,6 +43,7 @@ export function useDiagramEditor(initial: Diagram) {
     setError(null);
     try {
       const patch: DiagramPatch = {};
+      if (titleDirty) patch.title = title.trim() === "" ? DEFAULT_TITLE : title.trim();
       if (contentDirty) patch.content = content;
       if (layoutDirty) patch.layout = layout;
       const updated = await updateDiagram(diagram.shareToken, patch);
@@ -46,7 +54,7 @@ export function useDiagramEditor(initial: Diagram) {
       savingRef.current = false;
       setIsSaving(false);
     }
-  }, [content, contentDirty, layout, layoutDirty, diagram.shareToken, applyDiagram]);
+  }, [title, titleDirty, content, contentDirty, layout, layoutDirty, diagram.shareToken, applyDiagram]);
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -72,6 +80,8 @@ export function useDiagramEditor(initial: Diagram) {
 
   return {
     diagram,
+    title,
+    setTitle,
     content,
     setContent,
     layout,


### PR DESCRIPTION
## Summary
- Dashboard rows (`DiagramRow.tsx`) get a "Rename" button outside the row's link; commits on blur/Enter via a direct `updateDiagram` call, Escape cancels, blank falls back to "Untitled diagram".
- Editor header (`EditorHeader.tsx` / `useDiagramEditor.ts`) gets the same affordance, but the rename flows through the existing dirty-tracking/Save-button flow instead of saving immediately, matching how content/layout edits already behave.
- No backend changes — `PUT /api/diagrams/{shareToken}` already accepted and persisted `title`.

Closes #64

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `npm run test` — 124/124 unit tests pass (added coverage in `DiagramRow.test.tsx`, `EditorHeader.test.tsx`, `useDiagramEditor.test.ts`)
- [x] `npm run test:e2e` — 24/24 pass, including new rename coverage in `dashboard.spec.ts` and `editor.spec.ts`, and no regressions in the rest of the suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w