### PR TITLE
Memoize HighlightContext + defensive hover suppression during pan/zoom

### DIFF
--- a/frontend/e2e/relationships.spec.ts
+++ b/frontend/e2e/relationships.spec.ts
@@ -87,6 +87,40 @@ test("hovering a table highlights its connection and dims unrelated tables", asy
   await expect(unrelated).not.toHaveCSS("opacity", "0.4");
 });
 
+// Regression coverage for the #63 defensive mitigation (onMoveStart/onMoveEnd
+// hover suppression). The reported flicker itself never reproduced under any
+// gesture, so this can't assert against it directly — it asserts the
+// mitigation doesn't leave hover state stuck or broken across a pan gesture.
+test("panning the canvas doesn't leave the hover highlight stuck or broken afterward", async ({ page }) => {
+  await newSchemaDiagram(page);
+  await page.locator("textarea").fill(THREE_TABLE_DBML);
+
+  const orders = page.locator('[data-testid="table-node-orders"]');
+  const customers = page.locator('[data-testid="table-node-customers"]');
+  const unrelated = page.locator('[data-testid="table-node-unrelated"]');
+  const pane = page.locator(".react-flow__pane");
+
+  await orders.hover();
+  await expect(unrelated).toHaveCSS("opacity", "0.4");
+
+  const paneBox = await pane.boundingBox();
+  if (!paneBox) throw new Error("pane has no bounding box");
+  await page.mouse.move(paneBox.x + 20, paneBox.y + 20);
+  await page.mouse.down();
+  await page.mouse.move(paneBox.x + 150, paneBox.y + 150, { steps: 15 });
+  await page.mouse.up();
+
+  await page.mouse.move(0, 0);
+  await expect(unrelated).not.toHaveCSS("opacity", "0.4");
+
+  await customers.hover();
+  await expect(orders).not.toHaveCSS("opacity", "0.4");
+  await expect(unrelated).toHaveCSS("opacity", "0.4");
+
+  await page.mouse.move(0, 0);
+  await expect(unrelated).not.toHaveCSS("opacity", "0.4");
+});
+
 test("clicking a foreign-key field pans the canvas toward the referenced table and highlights it", async ({
   page,
 }) => {

--- a/frontend/src/components/SchemaDiagramEditor.tsx
+++ b/frontend/src/components/SchemaDiagramEditor.tsx
@@ -128,6 +128,7 @@ function FlowCanvas({
   const [hoveredTable, setHoveredTable] = useState<string | null>(null);
   const [jumpTables, setJumpTables] = useState<Set<string> | null>(null);
   const jumpTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isMovingRef = useRef(false);
 
   const { highlightedTables, highlightedEdgeIds } = useMemo(() => {
     if (hoveredTable) {
@@ -207,8 +208,28 @@ function FlowCanvas({
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         onNodesChange={onNodesChange}
-        onNodeMouseEnter={(_, node) => setHoveredTable(node.id)}
-        onNodeMouseLeave={() => setHoveredTable(null)}
+        // Defensive mitigation for #63 (never reproduced, root cause unconfirmed):
+        // freeze hover-driven highlight changes while the viewport is actively
+        // panning/zooming, so a stationary cursor can't have tables slide underneath
+        // it and flip highlight state. Ignore-only, not clear-on-start — clearing
+        // would pop the highlight off the instant an idle hover's mouse does an
+        // incidental wheel-zoom, which is worse than doing nothing. Also fires
+        // (harmlessly) around the initial fitView and handleFieldClick's setCenter,
+        // both of which go through the same viewport-transform path.
+        onMoveStart={() => {
+          isMovingRef.current = true;
+        }}
+        onMoveEnd={() => {
+          isMovingRef.current = false;
+        }}
+        onNodeMouseEnter={(_, node) => {
+          if (isMovingRef.current) return;
+          setHoveredTable(node.id);
+        }}
+        onNodeMouseLeave={() => {
+          if (isMovingRef.current) return;
+          setHoveredTable(null);
+        }}
         fitView
       >
         <Background />

--- a/frontend/src/components/SchemaDiagramEditor.tsx
+++ b/frontend/src/components/SchemaDiagramEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useContext, useMemo, useRef, useState } from "react";
+import { useCallback, useContext, useMemo, useRef, useState } from "react";
 import {
   applyNodeChanges,
   Background,
@@ -129,35 +129,48 @@ function FlowCanvas({
   const [jumpTables, setJumpTables] = useState<Set<string> | null>(null);
   const jumpTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const hoverConnections = hoveredTable ? connectionsForTable(hoveredTable, edges) : null;
-  const highlightedTables = hoverConnections
-    ? new Set([hoveredTable as string, ...hoverConnections.tableNames])
-    : jumpTables;
-  const highlightedEdgeIds = hoverConnections?.edgeIds ?? null;
+  const { highlightedTables, highlightedEdgeIds } = useMemo(() => {
+    if (hoveredTable) {
+      const conn = connectionsForTable(hoveredTable, edges);
+      return {
+        highlightedTables: new Set<string>([hoveredTable, ...conn.tableNames]),
+        highlightedEdgeIds: conn.edgeIds,
+      };
+    }
+    return { highlightedTables: jumpTables, highlightedEdgeIds: null as Set<string> | null };
+  }, [hoveredTable, jumpTables, edges]);
 
-  function handleFieldClick(tableName: string, fieldName: string) {
-    const targets = edgesForField(tableName, fieldName, edges);
-    if (targets.length === 0) {
-      return;
-    }
-    const destinations = new Set<string>();
-    for (const edge of targets) {
-      destinations.add(edge.source === tableName ? edge.target : edge.source);
-    }
-    const firstDestination = getNode([...destinations][0]);
-    if (firstDestination) {
-      setCenter(firstDestination.position.x + 110, firstDestination.position.y + 60, {
-        zoom: 1,
-        duration: 400,
-      });
-    }
-    destinations.add(tableName);
-    setJumpTables(destinations);
-    if (jumpTimeoutRef.current) {
-      clearTimeout(jumpTimeoutRef.current);
-    }
-    jumpTimeoutRef.current = setTimeout(() => setJumpTables(null), 1500);
-  }
+  const handleFieldClick = useCallback(
+    (tableName: string, fieldName: string) => {
+      const targets = edgesForField(tableName, fieldName, edges);
+      if (targets.length === 0) {
+        return;
+      }
+      const destinations = new Set<string>();
+      for (const edge of targets) {
+        destinations.add(edge.source === tableName ? edge.target : edge.source);
+      }
+      const firstDestination = getNode([...destinations][0]);
+      if (firstDestination) {
+        setCenter(firstDestination.position.x + 110, firstDestination.position.y + 60, {
+          zoom: 1,
+          duration: 400,
+        });
+      }
+      destinations.add(tableName);
+      setJumpTables(destinations);
+      if (jumpTimeoutRef.current) {
+        clearTimeout(jumpTimeoutRef.current);
+      }
+      jumpTimeoutRef.current = setTimeout(() => setJumpTables(null), 1500);
+    },
+    [edges, getNode, setCenter],
+  );
+
+  const highlightValue = useMemo(
+    () => ({ highlightedTables, highlightedEdgeIds, onFieldClick: handleFieldClick }),
+    [highlightedTables, highlightedEdgeIds, handleFieldClick],
+  );
 
   // flowEdges only carries data that's stable regardless of hover/click
   // state (cardinalities, type, self-loop), so it — like `nodes` — never
@@ -187,7 +200,7 @@ function FlowCanvas({
   );
 
   return (
-    <HighlightContext.Provider value={{ highlightedTables, highlightedEdgeIds, onFieldClick: handleFieldClick }}>
+    <HighlightContext.Provider value={highlightValue}>
       <ReactFlow
         nodes={nodes}
         edges={flowEdges}


### PR DESCRIPTION
## Summary

Two related, small changes to `SchemaDiagramEditor.tsx`'s `FlowCanvas`, surfaced while investigating #63 (table hover-highlight flickering while panning/zooming — reported by an end user, never reproduced despite two independent debugging sessions across Chromium/Firefox/WebKit and ~7 gesture types):

- **Confirmed-safe fix**: `HighlightContext.Provider`'s value was rebuilt as a fresh object every render (derived Sets and `handleFieldClick` too), causing every `TableNode`/`RelationshipEdge` context consumer to re-render on any unrelated re-render. Memoized the derivation, `handleFieldClick` (now `useCallback`), and the final context value.
- **Unconfirmed defensive mitigation**, per the issue's own originally-suggested fix: freeze hover-driven highlight updates while the viewport is actively panning/zooming (`onMoveStart`/`onMoveEnd` tracked via a ref), ignoring rather than clearing so idle-hover-plus-incidental-zoom — the case tested most thoroughly — doesn't get a new pop-off glitch introduced by this change.

This is **not** a confirmed fix for #63 — see the second commit message for the full investigation summary. Not using `Closes #63` deliberately; the issue stays open pending an actual repro (screen recording or device/browser details) from the original reporter.

## Test plan
- [x] `npm run lint` / `tsc --noEmit` clean
- [x] Full vitest unit suite: 124/124 passed
- [x] Full Playwright e2e suite (isolated Postgres + backend, `--workers=1`): 25/25 passed, including a new regression test (`e2e/relationships.spec.ts`) asserting a pan gesture doesn't leave hover state stuck or broken afterward
- [x] Verified the one flaky-looking failure seen under default parallel workers (`revisions.spec.ts`, unrelated to this change — RevisionPanel/unsaved-changes warning) is the pre-existing CPU-contention flake already documented for this repo's local Docker verification setup, not something this PR introduced — passes 100% serially

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w