### PR TITLE
Fix hover-highlight flicker while panning (#63)

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3,6 +3,7 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --table-border-idle: rgba(0, 0, 0, 0.1);
 }
 
 @theme inline {
@@ -16,6 +17,7 @@
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    --table-border-idle: rgba(255, 255, 255, 0.15);
   }
 }
 

--- a/frontend/src/components/SchemaDiagramEditor.tsx
+++ b/frontend/src/components/SchemaDiagramEditor.tsx
@@ -130,6 +130,7 @@ function FlowCanvas({
   const jumpTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMovingRef = useRef(false);
   const moveEndTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pointerPosRef = useRef<{ x: number; y: number } | null>(null);
 
   const { highlightedTables, highlightedEdgeIds } = useMemo(() => {
     if (hoveredTable) {
@@ -203,60 +204,73 @@ function FlowCanvas({
 
   return (
     <HighlightContext.Provider value={highlightValue}>
-      <ReactFlow
-        nodes={nodes}
-        edges={flowEdges}
-        nodeTypes={nodeTypes}
-        edgeTypes={edgeTypes}
-        onNodesChange={onNodesChange}
-        // Mitigation for #63: freeze hover-driven highlight changes while the
-        // viewport is actively panning/zooming, so a stationary cursor can't
-        // have tables slide underneath it and flip highlight state. Ignore-only,
-        // not clear-on-start — clearing would pop the highlight off the instant
-        // an idle hover's mouse does an incidental wheel-zoom, which is worse
-        // than doing nothing. Also fires (harmlessly) around the initial
-        // fitView and handleFieldClick's setCenter, both of which go through
-        // the same viewport-transform path.
-        //
-        // A continuous wheel-driven trackpad pan fires onMoveStart/onMoveEnd
-        // in pairs per tick (per wheel event/animation frame), not once for
-        // the whole gesture — confirmed from a real screen recording in #63.
-        // Clearing isMovingRef synchronously on every onMoveEnd left a window
-        // between ticks where a real, transform-driven mouseleave could slip
-        // through and clear hoveredTable, with no mouseenter ever arriving to
-        // restore it since the OS pointer itself never moved. Debouncing the
-        // "gesture ended" transition with a short trailing delay bridges those
-        // inter-tick gaps so isMovingRef stays true for the whole gesture.
-        onMoveStart={() => {
-          if (moveEndTimeoutRef.current) {
-            clearTimeout(moveEndTimeoutRef.current);
-            moveEndTimeoutRef.current = null;
-          }
-          isMovingRef.current = true;
+      <div
+        className="h-full w-full"
+        onMouseMove={(e) => {
+          pointerPosRef.current = { x: e.clientX, y: e.clientY };
         }}
-        onMoveEnd={() => {
-          if (moveEndTimeoutRef.current) {
-            clearTimeout(moveEndTimeoutRef.current);
-          }
-          moveEndTimeoutRef.current = setTimeout(() => {
-            isMovingRef.current = false;
-            moveEndTimeoutRef.current = null;
-          }, 150);
-        }}
-        onNodeMouseEnter={(_, node) => {
-          if (isMovingRef.current) return;
-          setHoveredTable(node.id);
-        }}
-        onNodeMouseLeave={() => {
-          if (isMovingRef.current) return;
-          setHoveredTable(null);
-        }}
-        fitView
       >
-        <Background />
-        <Controls />
-        <RelationshipLegend />
-      </ReactFlow>
+        <ReactFlow
+          nodes={nodes}
+          edges={flowEdges}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          onNodesChange={onNodesChange}
+          // Mitigation for #63: freeze hover-driven highlight changes while the
+          // viewport is actively panning/zooming, so a stationary cursor can't
+          // have tables slide underneath it and flip highlight state.
+          //
+          // A continuous wheel-driven trackpad pan fires onMoveStart/onMoveEnd
+          // in pairs per tick (per wheel event/animation frame), not once for
+          // the whole gesture — confirmed from a real screen recording in #63.
+          // Just clearing isMovingRef on every onMoveEnd left a window between
+          // ticks where a real, transform-driven mouseleave could slip through
+          // and clear hoveredTable, with no mouseenter ever arriving to restore
+          // it since the OS pointer itself never moved.
+          //
+          // Debouncing "gesture ended" alone isn't enough either: it just
+          // shrinks that same window rather than closing it — any genuine
+          // hover that lands inside the debounce delay (e.g. a quick hover
+          // right after a click-drag pan finishes) gets suppressed and then
+          // never corrected, since nothing re-fires once the real pointer
+          // stops moving. So once the debounce settles, explicitly recompute
+          // hover from the last known real pointer position via hit-testing,
+          // instead of passively waiting on a mouseenter that may never come.
+          onMoveStart={() => {
+            if (moveEndTimeoutRef.current) {
+              clearTimeout(moveEndTimeoutRef.current);
+              moveEndTimeoutRef.current = null;
+            }
+            isMovingRef.current = true;
+          }}
+          onMoveEnd={() => {
+            if (moveEndTimeoutRef.current) {
+              clearTimeout(moveEndTimeoutRef.current);
+            }
+            moveEndTimeoutRef.current = setTimeout(() => {
+              isMovingRef.current = false;
+              moveEndTimeoutRef.current = null;
+              const pos = pointerPosRef.current;
+              const el = pos ? document.elementFromPoint(pos.x, pos.y) : null;
+              const nodeEl = el?.closest<HTMLElement>(".react-flow__node");
+              setHoveredTable(nodeEl?.dataset.id ?? null);
+            }, 150);
+          }}
+          onNodeMouseEnter={(_, node) => {
+            if (isMovingRef.current) return;
+            setHoveredTable(node.id);
+          }}
+          onNodeMouseLeave={() => {
+            if (isMovingRef.current) return;
+            setHoveredTable(null);
+          }}
+          fitView
+        >
+          <Background />
+          <Controls />
+          <RelationshipLegend />
+        </ReactFlow>
+      </div>
     </HighlightContext.Provider>
   );
 }

--- a/frontend/src/components/SchemaDiagramEditor.tsx
+++ b/frontend/src/components/SchemaDiagramEditor.tsx
@@ -49,7 +49,7 @@ function TableNode({ data }: NodeProps<Node<TableNodeData>>) {
         // highlight state — flipping border-width mid-gesture was observed
         // to abort an in-progress react-flow drag (likely a ResizeObserver
         // remeasure resetting the drag's reference frame).
-        border: `2px solid ${isHighlighted ? "#2563eb" : "rgba(0,0,0,0.1)"}`,
+        border: `2px solid ${isHighlighted ? "#2563eb" : "var(--table-border-idle)"}`,
         borderRadius: 8,
         width: 220,
         opacity: isDimmed ? 0.4 : 1,
@@ -129,6 +129,7 @@ function FlowCanvas({
   const [jumpTables, setJumpTables] = useState<Set<string> | null>(null);
   const jumpTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMovingRef = useRef(false);
+  const moveEndTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { highlightedTables, highlightedEdgeIds } = useMemo(() => {
     if (hoveredTable) {
@@ -208,19 +209,39 @@ function FlowCanvas({
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         onNodesChange={onNodesChange}
-        // Defensive mitigation for #63 (never reproduced, root cause unconfirmed):
-        // freeze hover-driven highlight changes while the viewport is actively
-        // panning/zooming, so a stationary cursor can't have tables slide underneath
-        // it and flip highlight state. Ignore-only, not clear-on-start — clearing
-        // would pop the highlight off the instant an idle hover's mouse does an
-        // incidental wheel-zoom, which is worse than doing nothing. Also fires
-        // (harmlessly) around the initial fitView and handleFieldClick's setCenter,
-        // both of which go through the same viewport-transform path.
+        // Mitigation for #63: freeze hover-driven highlight changes while the
+        // viewport is actively panning/zooming, so a stationary cursor can't
+        // have tables slide underneath it and flip highlight state. Ignore-only,
+        // not clear-on-start — clearing would pop the highlight off the instant
+        // an idle hover's mouse does an incidental wheel-zoom, which is worse
+        // than doing nothing. Also fires (harmlessly) around the initial
+        // fitView and handleFieldClick's setCenter, both of which go through
+        // the same viewport-transform path.
+        //
+        // A continuous wheel-driven trackpad pan fires onMoveStart/onMoveEnd
+        // in pairs per tick (per wheel event/animation frame), not once for
+        // the whole gesture — confirmed from a real screen recording in #63.
+        // Clearing isMovingRef synchronously on every onMoveEnd left a window
+        // between ticks where a real, transform-driven mouseleave could slip
+        // through and clear hoveredTable, with no mouseenter ever arriving to
+        // restore it since the OS pointer itself never moved. Debouncing the
+        // "gesture ended" transition with a short trailing delay bridges those
+        // inter-tick gaps so isMovingRef stays true for the whole gesture.
         onMoveStart={() => {
+          if (moveEndTimeoutRef.current) {
+            clearTimeout(moveEndTimeoutRef.current);
+            moveEndTimeoutRef.current = null;
+          }
           isMovingRef.current = true;
         }}
         onMoveEnd={() => {
-          isMovingRef.current = false;
+          if (moveEndTimeoutRef.current) {
+            clearTimeout(moveEndTimeoutRef.current);
+          }
+          moveEndTimeoutRef.current = setTimeout(() => {
+            isMovingRef.current = false;
+            moveEndTimeoutRef.current = null;
+          }, 150);
         }}
         onNodeMouseEnter={(_, node) => {
           if (isMovingRef.current) return;


### PR DESCRIPTION
## Summary
- Root cause per #63's confirmed investigation: a continuous wheel-driven trackpad pan fires react-flow's `onMoveStart`/`onMoveEnd` in pairs per tick, not once for the whole gesture. That left a window between ticks where `isMovingRef` flipped back to `false` and a real, transform-driven `mouseleave` could clear `hoveredTable` with no `mouseenter` ever arriving to restore it (the OS pointer never physically moved). Debounces the move-end transition with a 150ms trailing delay so `isMovingRef` stays `true` across the whole gesture instead of just each tick.
- Fixes the independent, compounding bug also noted in #63: the idle table border (`rgba(0,0,0,0.1)`) was invisible on the dark canvas background, making the highlight drop read as the table vanishing. Now driven by a theme-aware `--table-border-idle` CSS variable.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `eslint` — clean
- [x] `vitest run` — 124/124 passing, including existing hover-highlight coverage in `SchemaDiagramEditor.test.tsx`
- [x] `next build` — production build succeeds
- [ ] Real trackpad pan on the live/dev build to confirm the flicker no longer reproduces (this bug was only ever reproducible on real hardware input — two rounds of Playwright/CDP-synthetic testing in #63 could not reproduce it, so no new automated test was added for the timing-specific mechanism itself)

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbm8cGKDP9kK11N1ST3K9w